### PR TITLE
Build the example projects on the CI to check the integrations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   matrix:
   - COMMAND="test-iOS"
   - COMMAND="test-native"
+  - COMMAND="examples"
 script:
 - set -o pipefail
 - xcodebuild -version


### PR DESCRIPTION
We have a command in our build script that iterates through the examples and checks that they can integrate Flow without errors. Adding this to the travis script will trigger the command.