### PR TITLE
Fix OnEventTypeDisposer retain cycle

### DIFF
--- a/Flow/Signal+Scheduling.swift
+++ b/Flow/Signal+Scheduling.swift
@@ -97,7 +97,7 @@ private final class OnEventTypeDisposer<Value>: Disposable {
         self.callback = callback
         mutex.initialize()
 
-        let disposable = onEventType(handleEventType)
+        let disposable = onEventType { [weak self] in self?.handleEventType($0) }
 
         mutex.lock()
         if self.callback == nil {
@@ -141,7 +141,8 @@ private final class OnEventTypeDisposer<Value>: Disposable {
             validate(eventType: eventType)
             callback(eventType)
         } else {
-            scheduler.async {
+            scheduler.async { [weak self] in
+                guard let `self` = self else { return }
                 // At the time we are scheduled, we might already been disposed
                 self.mutex.lock()
                 guard let callback = self.callback else {

--- a/FlowTests/SignalProviderTests.swift
+++ b/FlowTests/SignalProviderTests.swift
@@ -323,6 +323,17 @@ class SignalProviderTests: XCTestCase {
         bag.dispose()
     }
 
+    func testListenerDisposedOnDeinit() {
+        let signal = ReadWriteSignal(0)
+        let expectactions = XCTestExpectation(description: "Listener should be disposed")
+        expectactions.isInverted = true
+        _ = signal.onValue { _ in
+            expectactions.fulfill()
+        }
+        signal.value = 1
+        wait(for: [expectactions], timeout: 0.1)
+    }
+
     func testSkip() {
         test([1, 2, 3, 4], expected: [1, 2, 3, 4]) {
             $0.skip(first: 0)


### PR DESCRIPTION
Discovered a retain cycle between `OnEventTypeDisposer` and its `Disposable`
The effect was that `OnEventTypeDisposer` could not be disposed by itself

I added a test to showcase the problem