### PR TITLE
Make debugged ReadWriteSignals writable

### DIFF
--- a/Flow/Signal+Debug.swift
+++ b/Flow/Signal+Debug.swift
@@ -20,7 +20,7 @@ extension SignalProvider {
         let signal = providedSignal
         let message = message.map { $0 + " -> " } ?? ""
         let fileIdentifier = "<\(file.lastFileComponent):\(line)> (\(function))"
-        return CoreSignal(onEventType: { callback in
+        return CoreSignal(setValue: setter, onEventType: { callback in
             let bag = DisposeBag()
             bag += signal.onEventType(on: scheduler) { eventType in
                 let fullMessage = "\(dateFormatter.string(from: Date())): \(fileIdentifier): \(message)"

--- a/FlowTests/SignalTests.swift
+++ b/FlowTests/SignalTests.swift
@@ -100,4 +100,18 @@ class SignalTests: XCTestCase {
         }
         XCTAssertTrue(allIsCorrect)
     }
+
+    func testDebugReadWriteSignal() {
+        let readWriteSignal = ReadWriteSignal(0)
+        let debuggedSignal = readWriteSignal.debug(printer: { _ in })
+        let expectation = self.expectation(description: "Debugged signal sends a value")
+
+        let disposable = debuggedSignal.onValue { _ in
+            expectation.fulfill()
+        }
+        debuggedSignal.value = 5
+        disposable.dispose()
+
+        wait(for: [expectation], timeout: 1)
+    }
 }


### PR DESCRIPTION
Previously the code would crash if `debug` was used on a signal and then used as a `ReadWriteSignal` (see test).