### PR TITLE
Fixes a crash on Swift 4.2 when immediately (on the same line) modify…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added versions of `bindTo()` that can bind a non optional to an optional value.
 - Added `enable()` to `Enablable` similar as `disable()`.
 - Added more defaulted parameters to `Scheduler.init` for dispatch queues. 
+- Fixes a crash on Swift 4.2 when immediately (on the same line) modifying a `ReadWriteSignal`'s `value`.
 
 # 1.2.1
 

--- a/Flow/ReadWriteSignal.swift
+++ b/Flow/ReadWriteSignal.swift
@@ -59,11 +59,19 @@ public extension SignalProvider where Kind == ReadWrite {
     }
 }
 
+public extension CoreSignal where Kind == ReadWrite {
+    // The current value of `self`.
+    var value: Value {
+        get { return getter()! }
+        set { setter!(newValue) }
+    }
+}
+
 public extension SignalProvider where Kind == ReadWrite {
     // The current value of `self`.
     var value: Value {
-        get { return providedSignal.getter()! }
-        nonmutating set { providedSignal.setter!(newValue) }
+        get { return providedSignal.value }
+        nonmutating set { providedSignal.value = newValue }
     }
 }
 

--- a/FlowTests/FutureBasicTests.swift
+++ b/FlowTests/FutureBasicTests.swift
@@ -39,7 +39,6 @@ class FutureTest: XCTestCase {
     func cancelExpectation() -> XCTestExpectation {
         return expectation(description: "Receive cancel")
     }
-
 }
 
 class FutureBasicTests: FutureTest {
@@ -380,5 +379,9 @@ class FutureBasicTests: FutureTest {
                 e2.fulfill()
             }
         }
+    }
+
+    func testImmediateMutation() {
+        ReadWriteSignal(CGPoint.zero).value.x = 2
     }
 }


### PR DESCRIPTION
…ing a `ReadWriteSignal`'s `value`.

Should fix #34 

@fennecos & @mattiasjahnke Please verify in your code-base before we merge.