### PR TITLE
[WIP] Add FlowViewController

### DIFF
--- a/Flow.xcodeproj/project.pbxproj
+++ b/Flow.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		21E1D41C1D9502A300A91CA0 /* Future+Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E1D41B1D9502A300A91CA0 /* Future+Signal.swift */; };
 		7484FA6B212D9E930076FD3E /* Signal+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7484FA6A212D9E930076FD3E /* Signal+Debug.swift */; };
 		8E890FC106FB7A89BD1727CC /* EitherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E890194B06CBB3311E44757 /* EitherTests.swift */; };
+		C3A02E5B2163889E00DD8BF0 /* WriteSignal.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A02E5A2163889E00DD8BF0 /* WriteSignal.swift */; };
+		C3A02E5D2163891800DD8BF0 /* UIViewController+Flow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A02E5C2163891800DD8BF0 /* UIViewController+Flow.swift */; };
 		F610ABAE1D91743500A161AB /* Future+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F610ABA71D91743500A161AB /* Future+Additions.swift */; };
 		F610ABB01D91743500A161AB /* FutureQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = F610ABA91D91743500A161AB /* FutureQueue.swift */; };
 		F610ABB21D91743500A161AB /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = F610ABAB1D91743500A161AB /* Result.swift */; };
@@ -83,6 +85,8 @@
 		21E1D41B1D9502A300A91CA0 /* Future+Signal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Future+Signal.swift"; path = "Flow/Future+Signal.swift"; sourceTree = SOURCE_ROOT; };
 		7484FA6A212D9E930076FD3E /* Signal+Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Signal+Debug.swift"; path = "Flow/Signal+Debug.swift"; sourceTree = "<group>"; };
 		8E890194B06CBB3311E44757 /* EitherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EitherTests.swift; sourceTree = "<group>"; };
+		C3A02E5A2163889E00DD8BF0 /* WriteSignal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteSignal.swift; sourceTree = "<group>"; };
+		C3A02E5C2163891800DD8BF0 /* UIViewController+Flow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Flow.swift"; sourceTree = "<group>"; };
 		F610ABA61D91743500A161AB /* Future.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Future.swift; path = Flow/Future.swift; sourceTree = SOURCE_ROOT; };
 		F610ABA71D91743500A161AB /* Future+Additions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Future+Additions.swift"; path = "Flow/Future+Additions.swift"; sourceTree = SOURCE_ROOT; };
 		F610ABA91D91743500A161AB /* FutureQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FutureQueue.swift; path = Flow/FutureQueue.swift; sourceTree = SOURCE_ROOT; };
@@ -207,6 +211,7 @@
 				F6B6A6602056AF0300B9FC9D /* Signal.swift */,
 				F67C4797206CDDCC00BEBDFD /* FiniteSignal.swift */,
 				F6B6A65E2056AEA400B9FC9D /* ReadSignal.swift */,
+				C3A02E5A2163889E00DD8BF0 /* WriteSignal.swift */,
 				F6B6A6622056AF4300B9FC9D /* ReadWriteSignal.swift */,
 				F68EF3561FD590110001129C /* SignalProvider.swift */,
 				F66C47A820077BC700333410 /* Signal+Listeners.swift */,
@@ -230,6 +235,7 @@
 				F6AD20561E2FB5320082CF27 /* UIControls+Extensions.swift */,
 				F68EF3541FD58FD20001129C /* UIView+Signal.swift */,
 				F66835CE2091B887002D2676 /* UIView+EditingMenu.swift */,
+				C3A02E5C2163891800DD8BF0 /* UIViewController+Flow.swift */,
 				F667FCD7200604570014DA7D /* Enablable.swift */,
 				F6FF03DB1D926AC300B93771 /* TargetActionable.swift */,
 				F6E752302099B60A0092EDAA /* HasEventListeners.swift */,
@@ -435,6 +441,7 @@
 				21E1D41C1D9502A300A91CA0 /* Future+Signal.swift in Sources */,
 				215DEF311DEC365900CEB724 /* Recursive.swift in Sources */,
 				F6E752312099B60A0092EDAA /* HasEventListeners.swift in Sources */,
+				C3A02E5D2163891800DD8BF0 /* UIViewController+Flow.swift in Sources */,
 				F610ABAE1D91743500A161AB /* Future+Additions.swift in Sources */,
 				F68EF3571FD590110001129C /* SignalProvider.swift in Sources */,
 				F6B57E891E30B01700703CA7 /* OrderedCallbacker.swift in Sources */,
@@ -443,6 +450,7 @@
 				F6B6A65F2056AEA400B9FC9D /* ReadSignal.swift in Sources */,
 				F6FF03E71D926AC300B93771 /* Utilities.swift in Sources */,
 				F66C47A720077B2500333410 /* Signal+Combiners.swift in Sources */,
+				C3A02E5B2163889E00DD8BF0 /* WriteSignal.swift in Sources */,
 				F662C0A71FDFDEB300E5F869 /* Signal+Scheduling.swift in Sources */,
 				F6FF03E41D926AC300B93771 /* CoreSignal.swift in Sources */,
 				F67C4798206CDDCC00BEBDFD /* FiniteSignal.swift in Sources */,

--- a/Flow.xcodeproj/project.pbxproj
+++ b/Flow.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		8E890FC106FB7A89BD1727CC /* EitherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E890194B06CBB3311E44757 /* EitherTests.swift */; };
 		C3A02E5B2163889E00DD8BF0 /* WriteSignal.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A02E5A2163889E00DD8BF0 /* WriteSignal.swift */; };
 		C3A02E5D2163891800DD8BF0 /* UIViewController+Flow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A02E5C2163891800DD8BF0 /* UIViewController+Flow.swift */; };
+		C3A02F302164F0CD00DD8BF0 /* UIApplication+Flow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A02F2F2164F0CD00DD8BF0 /* UIApplication+Flow.swift */; };
 		F610ABAE1D91743500A161AB /* Future+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F610ABA71D91743500A161AB /* Future+Additions.swift */; };
 		F610ABB01D91743500A161AB /* FutureQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = F610ABA91D91743500A161AB /* FutureQueue.swift */; };
 		F610ABB21D91743500A161AB /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = F610ABAB1D91743500A161AB /* Result.swift */; };
@@ -87,6 +88,7 @@
 		8E890194B06CBB3311E44757 /* EitherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EitherTests.swift; sourceTree = "<group>"; };
 		C3A02E5A2163889E00DD8BF0 /* WriteSignal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteSignal.swift; sourceTree = "<group>"; };
 		C3A02E5C2163891800DD8BF0 /* UIViewController+Flow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Flow.swift"; sourceTree = "<group>"; };
+		C3A02F2F2164F0CD00DD8BF0 /* UIApplication+Flow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+Flow.swift"; sourceTree = "<group>"; };
 		F610ABA61D91743500A161AB /* Future.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Future.swift; path = Flow/Future.swift; sourceTree = SOURCE_ROOT; };
 		F610ABA71D91743500A161AB /* Future+Additions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Future+Additions.swift"; path = "Flow/Future+Additions.swift"; sourceTree = SOURCE_ROOT; };
 		F610ABA91D91743500A161AB /* FutureQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FutureQueue.swift; path = Flow/FutureQueue.swift; sourceTree = SOURCE_ROOT; };
@@ -236,6 +238,7 @@
 				F68EF3541FD58FD20001129C /* UIView+Signal.swift */,
 				F66835CE2091B887002D2676 /* UIView+EditingMenu.swift */,
 				C3A02E5C2163891800DD8BF0 /* UIViewController+Flow.swift */,
+				C3A02F2F2164F0CD00DD8BF0 /* UIApplication+Flow.swift */,
 				F667FCD7200604570014DA7D /* Enablable.swift */,
 				F6FF03DB1D926AC300B93771 /* TargetActionable.swift */,
 				F6E752302099B60A0092EDAA /* HasEventListeners.swift */,
@@ -452,6 +455,7 @@
 				F66C47A720077B2500333410 /* Signal+Combiners.swift in Sources */,
 				C3A02E5B2163889E00DD8BF0 /* WriteSignal.swift in Sources */,
 				F662C0A71FDFDEB300E5F869 /* Signal+Scheduling.swift in Sources */,
+				C3A02F302164F0CD00DD8BF0 /* UIApplication+Flow.swift in Sources */,
 				F6FF03E41D926AC300B93771 /* CoreSignal.swift in Sources */,
 				F67C4798206CDDCC00BEBDFD /* FiniteSignal.swift in Sources */,
 				F610ABB31D91743500A161AB /* Locking.swift in Sources */,

--- a/Flow/Signal.swift
+++ b/Flow/Signal.swift
@@ -111,7 +111,7 @@ public extension CoreSignal where Kind == Plain {
     }
 }
 
-public extension SignalProvider where Kind == Plain {
+public extension SignalProvider where Kind.DropWrite == Plain {
     /// Returns a new readable signal evaluating `getValue()` for its current value.
     func readable(getValue: @escaping () -> Value) -> ReadSignal<Value> {
         let signal = providedSignal

--- a/Flow/SignalProvider.swift
+++ b/Flow/SignalProvider.swift
@@ -57,6 +57,13 @@ public enum Read: SignalKind {
     public typealias PotentiallyRead = Read
 }
 
+/// A signal kind with write access but no read access
+public enum Write: SignalKind {
+    public typealias DropWrite = Plain
+    public typealias DropReadWrite = Plain
+    public typealias PotentiallyRead = ReadWrite
+}
+
 /// A signal kind with both read and write access
 public enum ReadWrite: SignalKind {
     public typealias DropWrite = Read

--- a/UIApplication+Flow.swift
+++ b/UIApplication+Flow.swift
@@ -1,0 +1,49 @@
+//
+//  UIApplication+Flow.swift
+//  Flow
+//
+//  Created by Carl Ekman on 2018-10-03.
+//  Copyright © 2018 iZettle. All rights reserved.
+//
+
+import UIKit
+
+public extension UIApplication {
+    /// The `UIApplication` callback events that signify a state change.
+    enum StateChangeCallback {
+        case willEnterForeground, willResignActive, didBecomeActive, didEnterBackground
+    }
+
+    /// A signal containing the new `UIApplicationState` whenever it is about to (or did) change.
+    var appStateSignal: Signal<UIApplicationState> {
+        return signal(for: .willEnterForeground, .willResignActive, .didBecomeActive, .didEnterBackground)
+            .map { ($0.object as? UIApplication)?.applicationState ?? .active }
+            .distinct()
+    }
+
+    /// The notification signal for a given `StateChangeCallback`.
+    func signal(for appStateCallbacks: StateChangeCallback...) -> Signal<(Notification)> {
+        var signals = [Signal<(Notification)>]()
+        for callback in appStateCallbacks {
+            let signal = NotificationCenter.default.signal(forName: callback.notificationName)
+            signals.append(signal)
+        }
+        return merge(signals)
+    }
+}
+
+private extension UIApplication.StateChangeCallback {
+    /// The related notification name.
+    var notificationName: NSNotification.Name {
+        switch self {
+        case .willEnterForeground:
+            return .UIApplicationWillEnterForeground
+        case .willResignActive:
+            return .UIApplicationWillResignActive
+        case .didBecomeActive:
+            return .UIApplicationDidBecomeActive
+        case .didEnterBackground:
+            return .UIApplicationDidEnterBackground
+        }
+    }
+}

--- a/UIViewController+Flow.swift
+++ b/UIViewController+Flow.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public class FlowViewController: UIViewController {
+public final class FlowViewController: UIViewController {
     private var viewDidLoadSignal = WriteSignal<()>()
 
     private var viewWillAppearSignal = WriteSignal<Bool>()

--- a/UIViewController+Flow.swift
+++ b/UIViewController+Flow.swift
@@ -1,0 +1,96 @@
+//
+//  UIViewController+Flow.swift
+//  Flow
+//
+//  Created by Carl Ekman on 2018-10-02.
+//  Copyright © 2018 iZettle. All rights reserved.
+//
+
+import UIKit
+
+public class FlowViewController: UIViewController {
+    private var viewDidLoadSignal = WriteSignal<()>()
+    private var viewWillAppearSignal = WriteSignal<Bool>()
+    private var viewDidAppearSignal = WriteSignal<Bool>()
+    private var viewWillDisappearSignal = WriteSignal<Bool>()
+    private var viewDidDisappearSignal = WriteSignal<Bool>()
+    private var viewWillLayoutSubviewsSignal = WriteSignal<()>()
+    private var viewDidLayoutSubviewsSignal = WriteSignal<()>()
+    private var didReceiveMemoryWarningSignal = WriteSignal<()>()
+}
+
+extension FlowViewController {
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+        viewDidLoadSignal.emit()
+    }
+
+    override public func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        viewWillAppearSignal.emit(animated)
+    }
+
+    override public func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        viewDidAppearSignal.emit(animated)
+    }
+
+    override public func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        viewWillDisappearSignal.emit(animated)
+    }
+
+    override public func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        viewDidDisappearSignal.emit(animated)
+    }
+
+    override public func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+        viewWillLayoutSubviewsSignal.emit()
+    }
+
+    override public func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        viewDidLayoutSubviewsSignal.emit()
+    }
+
+    override public func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        didReceiveMemoryWarningSignal.emit()
+    }
+}
+
+extension FlowViewController {
+    public var didLoad: Signal<()> {
+        return viewDidLoadSignal.plain()
+    }
+
+    public var willAppear: Signal<Bool> {
+        return viewWillAppearSignal.plain()
+    }
+
+    public var didAppear: Signal<Bool> {
+        return viewDidAppearSignal.plain()
+    }
+
+    public var willDisappear: Signal<Bool> {
+        return viewWillDisappearSignal.plain()
+    }
+
+    public var didDisappear: Signal<Bool> {
+        return viewDidDisappearSignal.plain()
+    }
+
+    public var willLayoutSubviews: Signal<()> {
+        return viewWillLayoutSubviewsSignal.plain()
+    }
+
+    public var didLayoutSubviews: Signal<()> {
+        return viewDidLayoutSubviewsSignal.plain()
+    }
+
+    public var receivedMemoryWarning: Signal<()> {
+        return didReceiveMemoryWarningSignal.plain()
+    }
+}

--- a/UIViewController+Flow.swift
+++ b/UIViewController+Flow.swift
@@ -99,38 +99,3 @@ extension FlowViewController {
         return didReceiveMemoryWarningSignal.plain()
     }
 }
-
-extension FlowViewController {
-    /// The current `UIApplicationState`, as observed through `NotificationCenter`.
-    /// Will only emit values if `observeAppStateChanges()` has been called.
-    public var appStateSignal: Signal<UIApplicationState> {
-        return stateSignal.plain().distinct()
-    }
-
-    /// Call this to begin observing NSApplicationState updates, emitted to `appStateSignal`.
-    public func observeAppStateChanges() -> Disposable {
-        let app = UIApplication.shared
-        let center = NotificationCenter.default
-        let selector = #selector(FlowViewController.updateApplicationState(notification:))
-
-        let willEnterForeground = NSNotification.Name.UIApplicationWillEnterForeground
-        let willResignActive = NSNotification.Name.UIApplicationWillResignActive
-        let didBecomeActive = NSNotification.Name.UIApplicationDidBecomeActive
-        let didEnterBackground = NSNotification.Name.UIApplicationDidEnterBackground
-
-        center.addObserver(self, selector: selector, name: willEnterForeground, object: app)
-        center.addObserver(self, selector: selector, name: willResignActive, object: app)
-        center.addObserver(self, selector: selector, name: didBecomeActive, object: app)
-        center.addObserver(self, selector: selector, name: didEnterBackground, object: app)
-
-        let bag = DisposeBag()
-        bag += { center.removeObserver(self) }
-        return bag
-    }
-
-    /// Internal callback for the observers.
-    @objc private func updateApplicationState(notification: NSNotification) {
-        let state = (notification.object as? UIApplication)?.applicationState ?? .active
-        stateSignal.emit(state)
-    }
-}

--- a/WriteSignal.swift
+++ b/WriteSignal.swift
@@ -1,0 +1,55 @@
+//
+//  WriteSignal.swift
+//  Flow
+//
+//  Created by Carl Ekman on 2018-10-02.
+//  Copyright © 2018 iZettle. All rights reserved.
+//
+
+import Foundation
+
+public typealias WriteSignal<Value> = CoreSignal<Write, Value>
+
+public extension CoreSignal where Kind == Write {
+
+    convenience init(willSet: @escaping (Value) -> Void = { _ in }, didSet: @escaping (Value) -> Void = { _ in }) {
+        let callbacker = Callbacker<Value>()
+        self.init(setValue: { val in
+            willSet(val)
+            callbacker.callAll(with: val)
+            didSet(val)
+        }, options: [], onInternalEvent: { callback in
+            return callbacker.addCallback {
+                callback(.value($0))
+            }
+        })
+    }
+
+    convenience init(setValue: @escaping (Value) -> Void) {
+        let callbacker = Callbacker<Value>()
+        self.init(setValue: { setValue($0); callbacker.callAll(with: $0) }, options: [], onInternalEvent: { callback in
+            return callbacker.addCallback {
+                callback(.value($0))
+            }
+        })
+    }
+}
+
+public extension SignalProvider where Kind == Write {
+    /// Writes a value to the signal.
+    func emit(_ value: Value) -> Void {
+        self.providedSignal.setter!(value)
+    }
+
+    /// Returns a new signal with no access to a current `value`.
+    func plain() -> Signal<Value> {
+        return Signal(self)
+    }
+}
+
+public extension SignalProvider where Kind == Write, Value == Void {
+    /// Writes a value of Void to the signal.
+    func emit() -> Void {
+        self.providedSignal.setter!(())
+    }
+}


### PR DESCRIPTION
### What is this?
This is just a work-in-progress PR for feedback on this group of concepts.

#### FlowViewController

Some of us have spoken about a `UIViewController` subclass that provides signals for lifecycle callbacks. I took the liberty of implementing a rough proof of concept.

I tried it out with `Presentation` and it makes for pretty nice composing. I don't know if something like this already exists, or if this is at all a good idea. Would very much like some feedback on this approach!

#### App state observation

There is now an added `UIApplication` extension concept for observing app state changes.

#### WriteSignal<T>
~~This is a new addition, which may or may not be a good idea. It's mainly for writing values to internal signals that are later exposed as `Signal<T>` through `plain()`.~~

The same effect can be achieved by using callbackers.