### PR TITLE
Bugfix: Updated `Future.abort(forFutures:)` to more correctly handl…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.1
+
+- Bugfix: Updated `Future.abort(forFutures:)` to more correctly handle repetition.
+
 # 1.3
 
 - Added versions of `bindTo()` that can bind a non optional to an optional value.

--- a/Flow/Future+Combiners.swift
+++ b/Flow/Future+Combiners.swift
@@ -177,10 +177,10 @@ public extension Future {
     /// The returned future completes when either `self` of any of the `futures` completes, whichever completes first.
     /// If any of the futures in `futures` completes first the returned future will always fail with either the future's error or `FutureError.aborted` if it completes successfully.
     func abort(forFutures futures: [Future<()>]) -> Future {
-        return Future { completion in
-            let future = self.onResult(on: .none, completion)
+        return Future { completion, mover in
+            let future = mover.moveInside(self).onResult(on: .none, completion)
 
-            let aborts = Flow.select(between: futures).onResult(on: .none) { result in
+            let aborts = Flow.select(between: futures.map(mover.moveInside)).onResult(on: .none) { result in
                 completion(.failure(result.error ?? FutureError.aborted))
             }
 

--- a/FlowTests/FutureUtilitiesTests.swift
+++ b/FlowTests/FutureUtilitiesTests.swift
@@ -149,6 +149,18 @@ class FutureUtilitiesTests: FutureTest {
         }
     }
 
+    func testAbortForFuturesRepeat() {
+        let e = errorExpectation()
+        e.expectedFulfillmentCount = 4
+        testFuture(timeout: 2) {
+            Future()
+                .onValue { e.fulfill() }
+                .delay(by: 10).abort(forFutures: [ Future().onValue { e.fulfill() }.delay(by: 0.1) ])
+                .mapResult { _ in () }
+                .repeatAndCollect(repeatCount: 1)
+        }
+    }
+
     func testIgnoreAbort() {
         testFuture(timeout: 1, cancelAfterDelay: 0.1) { () -> Future<Int> in
             let e = errorExpectation()


### PR DESCRIPTION
…e repetition.