### PR TITLE
Making `Signal`'s `flatMapLatest` more flexible with mixing kinds of signals.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # 1.4
-- Added new `Signal` `flatMap` transformation that allows more flexible mixing of signal types between `self` and the signal returned from `transform`.
-- Deprecated  `flatMapLatest` that is being replaced by the more flexible `flatMap` version.
+- Updated the `Signal.flatMapLatest()` transformation to allow more flexible mixing of signal types between `self` and the signal returned from `transform`.
 
 # 1.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4
+- Added new `Signal` `flatMap` transformation that allows more flexible mixing of signal types between `self` and the signal returned from `transform`.
+- Deprecated  `flatMapLatest` that is being replaced by the more flexible `flatMap` version.
+
 # 1.3.1
 
 - Bugfix: Updated `Future.abort(forFutures:)` to more correctly handle repetition.

--- a/Flow/Future+Signal.swift
+++ b/Flow/Future+Signal.swift
@@ -31,7 +31,7 @@ public extension SignalProvider {
     /// Returns a new signal forwarding the value from the future returned from `transform` unless the future fails, where the returned signal terminates with the future's error.
     /// - Note: If `self` signals a value, any previous future returned from `transform` will be cancelled.
     func mapLatestToFuture<T>(on scheduler: Scheduler = .current, _ transform: @escaping (Value) -> Future<T>) -> FiniteSignal<T> {
-        return FiniteSignal(self).flatMapLatest(on: scheduler) { value in
+        return FiniteSignal(self).flatMap(on: scheduler) { value in
             transform(value).valueSignal
         }
     }

--- a/Flow/Future+Signal.swift
+++ b/Flow/Future+Signal.swift
@@ -31,7 +31,7 @@ public extension SignalProvider {
     /// Returns a new signal forwarding the value from the future returned from `transform` unless the future fails, where the returned signal terminates with the future's error.
     /// - Note: If `self` signals a value, any previous future returned from `transform` will be cancelled.
     func mapLatestToFuture<T>(on scheduler: Scheduler = .current, _ transform: @escaping (Value) -> Future<T>) -> FiniteSignal<T> {
-        return FiniteSignal(self).flatMap(on: scheduler) { value in
+        return FiniteSignal(self).flatMapLatest(on: scheduler) { value in
             transform(value).valueSignal
         }
     }

--- a/Flow/Signal+Transforms.swift
+++ b/Flow/Signal+Transforms.swift
@@ -101,11 +101,6 @@ public extension SignalProvider {
         })
     }
 
-    @available(*, deprecated, renamed: "flatMap", message: "Use `flatMap` instead that allows greater flexibilty with provided signal types.")
-    func flatMapLatest<K, T>(on scheduler: Scheduler = .current, _ transform: @escaping (Value) -> CoreSignal<K, T>) -> CoreSignal<Kind.DropWrite, T> where K.DropWrite == Kind.DropWrite {
-        return _flatMap(on: scheduler, transform)
-    }
-
     /// Returns a new signal transforming values using `transform`
     ///
     ///     1)---2----3----4----|
@@ -632,7 +627,7 @@ public extension SignalProvider where Kind == Plain {
     ///     ---a--------b------------
     ///        |        |
     ///     +-------------------------+
-    ///     | flatMap()               |
+    ///     | flatMapLatest()         |
     ///     +-------------------------+
     ///     ---s1-------s2-----------|
     ///        |        |
@@ -640,8 +635,8 @@ public extension SignalProvider where Kind == Plain {
     ///
     /// - Note: If `self` signals a value, any a previous signal returned from `transform` will be disposed.
     /// - Note: If the signal returned from `transform` is terminated, the returned signal will terminated as well.
-    func flatMap<K, T>(on scheduler: Scheduler = .current, _ transform: @escaping (Value) -> CoreSignal<K, T>) -> CoreSignal<K.DropReadWrite, T> {
-        return _flatMap(on: scheduler, transform)
+    func flatMapLatest<K, T>(on scheduler: Scheduler = .current, _ transform: @escaping (Value) -> CoreSignal<K, T>) -> CoreSignal<K.DropReadWrite, T> {
+        return _flatMapLatest(on: scheduler, transform)
     }
 }
 
@@ -651,7 +646,7 @@ public extension SignalProvider where Kind == Finite {
     ///     ---a--------b------------|
     ///        |        |
     ///     +-------------------------+
-    ///     | flatMap()               |
+    ///     | flatMapLatest           |
     ///     +-------------------------+
     ///     ---s1-------s2-----------|
     ///        |        |
@@ -660,8 +655,8 @@ public extension SignalProvider where Kind == Finite {
     ///
     /// - Note: If `self` signals a value, any a previous signal returned from `transform` will be disposed.
     /// - Note: If either `self` of the signal returned from `transform` are terminated, the returned signal will terminated as well.
-    func flatMap<K, T>(on scheduler: Scheduler = .current, _ transform: @escaping (Value) -> CoreSignal<K, T>) -> FiniteSignal<T> {
-        return _flatMap(on: scheduler, transform)
+    func flatMapLatest<K, T>(on scheduler: Scheduler = .current, _ transform: @escaping (Value) -> CoreSignal<K, T>) -> FiniteSignal<T> {
+        return _flatMapLatest(on: scheduler, transform)
     }
 }
 
@@ -671,7 +666,7 @@ public extension SignalProvider where Kind.DropWrite == Read {
     ///     0)--------a---------b-------
     ///               |         |
     ///     +----------------------------+
-    ///     | flatMap()                  |
+    ///     | flatMapLatest()            |
     ///     +----------------------------+
     ///     s0)-------s1--------s2------|
     ///               |         |
@@ -679,13 +674,13 @@ public extension SignalProvider where Kind.DropWrite == Read {
     ///
     /// - Note: If `self` signals a value, any a previous signal returned from `transform` will be disposed.
     /// - Note: If the signal returned from `transform` is terminated, the returned signal will terminated as well.
-    func flatMap<K, T>(on scheduler: Scheduler = .current, _ transform: @escaping (Value) -> CoreSignal<K, T>) -> CoreSignal<K, T> {
-        return _flatMap(on: scheduler, transform)
+    func flatMapLatest<K, T>(on scheduler: Scheduler = .current, _ transform: @escaping (Value) -> CoreSignal<K, T>) -> CoreSignal<K, T> {
+        return _flatMapLatest(on: scheduler, transform)
     }
 }
 
 private extension SignalProvider {
-    func _flatMap<KI, T, KO>(on scheduler: Scheduler = .current, _ transform: @escaping (Value) -> CoreSignal<KI, T>) -> CoreSignal<KO, T> {
+    func _flatMapLatest<KI, T, KO>(on scheduler: Scheduler = .current, _ transform: @escaping (Value) -> CoreSignal<KI, T>) -> CoreSignal<KO, T> {
         let signal = providedSignal
 
         let mutex = Mutex()

--- a/Flow/Signal+Transforms.swift
+++ b/Flow/Signal+Transforms.swift
@@ -101,64 +101,9 @@ public extension SignalProvider {
         })
     }
 
-    /// Returns a new signal forwarding the values from the signal returned from `transform`.
-    ///
-    ///     ---a--------b------------|
-    ///        |        |
-    ///     +-------------------------+
-    ///     | flatMapLatest() - plain |
-    ///     +-------------------------+
-    ///     ---s1-------s2-----------|
-    ///        |        |
-    ///     -----1---2-----1---2--3--|
-    ///
-    ///     0)--------a---------b----------|
-    ///               |         |
-    ///     +----------------------------+
-    ///     | flatMapLatest() - readable |
-    ///     +----------------------------+
-    ///     s0)-------s1--------s2---------|
-    ///               |         |
-    ///     0)--1--2--0--1--2---0--1--2----|
-    ///
-    /// - Note: If `self` signals a value, any a previous signal returned from `transform` will be disposed.
-    /// - Note: If `self` and `other` are both readable their current values will be used as initial values.
-    /// - Note: If either `self` of the signal returned from `transform` are terminated, the returned signal will terminated as well.
+    @available(*, deprecated, renamed: "flatMap", message: "Use `flatMap` instead that allows greater flexibilty with provided signal types.")
     func flatMapLatest<K, T>(on scheduler: Scheduler = .current, _ transform: @escaping (Value) -> CoreSignal<K, T>) -> CoreSignal<Kind.DropWrite, T> where K.DropWrite == Kind.DropWrite {
-        let signal = providedSignal
-        return CoreSignal(onEventType: { callback in
-            let latestBag = DisposeBag()
-            let bag = DisposeBag(latestBag)
-            bag += signal.onEventType(on: scheduler) { eventType in
-                switch eventType {
-                case .initial(nil):
-                    callback(.initial(nil))
-                case .initial(let val?):
-                    latestBag += scheduler.sync { transform(val) }.onEventType(callback)
-                case let .event(.value(val)):
-                    let isFirstEvent = latestBag.isEmpty
-                    latestBag.dispose()
-                    latestBag += transform(val).onEventType { eventType in
-                        switch eventType {
-                        case .initial(let val?):
-                            if isFirstEvent {
-                                callback(eventType) // Just forward first initial
-                            } else {
-                                callback(.event(.value(val))) // Pass upcoming initials as values
-                            }
-                        case .initial(nil):
-                            break
-                        case .event:
-                            callback(eventType)
-                        }
-                    }
-                case .event(.end(let error)):
-                    callback(.event(.end(error)))
-                }
-            }
-
-            return bag
-        })
+        return _flatMap(on: scheduler, transform)
     }
 
     /// Returns a new signal transforming values using `transform`
@@ -678,6 +623,117 @@ public extension SignalProvider {
 
             return state
         }
+    }
+}
+
+public extension SignalProvider where Kind == Plain {
+    /// Returns a new signal forwarding the values from the signal returned from `transform`.
+    ///
+    ///     ---a--------b------------
+    ///        |        |
+    ///     +-------------------------+
+    ///     | flatMap()               |
+    ///     +-------------------------+
+    ///     ---s1-------s2-----------|
+    ///        |        |
+    ///     -----1---2-----1---2--3--|
+    ///
+    /// - Note: If `self` signals a value, any a previous signal returned from `transform` will be disposed.
+    /// - Note: If the signal returned from `transform` is terminated, the returned signal will terminated as well.
+    func flatMap<K, T>(on scheduler: Scheduler = .current, _ transform: @escaping (Value) -> CoreSignal<K, T>) -> CoreSignal<K.DropReadWrite, T> {
+        return _flatMap(on: scheduler, transform)
+    }
+}
+
+public extension SignalProvider where Kind == Finite {
+    /// Returns a new signal forwarding the values from the signal returned from `transform`.
+    ///
+    ///     ---a--------b------------|
+    ///        |        |
+    ///     +-------------------------+
+    ///     | flatMap()               |
+    ///     +-------------------------+
+    ///     ---s1-------s2-----------|
+    ///        |        |
+    ///     -----1---2-----1---2--3--|
+    ///
+    ///
+    /// - Note: If `self` signals a value, any a previous signal returned from `transform` will be disposed.
+    /// - Note: If either `self` of the signal returned from `transform` are terminated, the returned signal will terminated as well.
+    func flatMap<K, T>(on scheduler: Scheduler = .current, _ transform: @escaping (Value) -> CoreSignal<K, T>) -> FiniteSignal<T> {
+        return _flatMap(on: scheduler, transform)
+    }
+}
+
+public extension SignalProvider where Kind.DropWrite == Read {
+    /// Returns a new signal forwarding the values from the signal returned from `transform`.
+    ///
+    ///     0)--------a---------b-------
+    ///               |         |
+    ///     +----------------------------+
+    ///     | flatMap()                  |
+    ///     +----------------------------+
+    ///     s0)-------s1--------s2------|
+    ///               |         |
+    ///     0)--1--2--0--1--2---0--1--2-|
+    ///
+    /// - Note: If `self` signals a value, any a previous signal returned from `transform` will be disposed.
+    /// - Note: If the signal returned from `transform` is terminated, the returned signal will terminated as well.
+    func flatMap<K, T>(on scheduler: Scheduler = .current, _ transform: @escaping (Value) -> CoreSignal<K, T>) -> CoreSignal<K, T> {
+        return _flatMap(on: scheduler, transform)
+    }
+}
+
+private extension SignalProvider {
+    func _flatMap<KI, T, KO>(on scheduler: Scheduler = .current, _ transform: @escaping (Value) -> CoreSignal<KI, T>) -> CoreSignal<KO, T> {
+        let signal = providedSignal
+
+        let mutex = Mutex()
+        var setter: ((T) -> ())? = nil
+        func setValue(_ value: T) {
+            let setValue = mutex.protect { setter ?? transform(signal.getter()!).setter! }
+            setValue(value)
+        }
+
+        return CoreSignal(setValue: setValue, onEventType: { callback in
+            let latestBag = DisposeBag()
+            let bag = DisposeBag(latestBag)
+            bag += { mutex.protect { setter = nil } }
+
+            bag += signal.onEventType(on: scheduler) { eventType in
+                switch eventType {
+                case .initial(nil):
+                    callback(.initial(nil))
+                case .initial(let val?):
+                    let signal = scheduler.sync { transform(val) }
+                    mutex.protect { setter = signal.setter }
+                    latestBag += signal.onEventType(callback)
+                case let .event(.value(val)):
+                    let isFirstEvent = latestBag.isEmpty
+                    latestBag.dispose()
+                    let signal = transform(val)
+                    mutex.protect { setter = signal.setter }
+                    latestBag += signal.onEventType { eventType in
+                        switch eventType {
+                        case .initial(let val?) where KO.isReadable:
+                            if isFirstEvent {
+                                callback(eventType) // Just forward first initial
+                            } else {
+                                callback(.event(.value(val))) // Pass upcoming initials as values
+                            }
+                        case .initial:
+                            break
+                        case .event:
+                            callback(eventType)
+                        }
+                    }
+                case .event(.end(let error)):
+                    callback(.event(.end(error)))
+                }
+            }
+
+            return bag
+        })
     }
 }
 

--- a/FlowTests/SignalProviderTests.swift
+++ b/FlowTests/SignalProviderTests.swift
@@ -1769,14 +1769,14 @@ class SignalProviderTests: XCTestCase {
 
     }
 
-    func testFlatMapNoSource() {
+    func testFlatMapLatestNoSource() {
         let o = ReadWriteSignal(0) // outer
         let i = ReadWriteSignal(0) // inner
 
         let bag = DisposeBag()
         var r = 0
         var cnt = 0
-        bag += o.plain().flatMap { val in
+        bag += o.plain().flatMapLatest { val in
             return i.plain().map { val + $0 }
         }.onValue {
             cnt += 1
@@ -1800,14 +1800,14 @@ class SignalProviderTests: XCTestCase {
         XCTAssertEqual(cnt, 3)
     }
 
-    func testFlatMapHasSource() {
+    func testFlatMapLatestHasSource() {
         let o = ReadWriteSignal(1) // outer
         let i = ReadWriteSignal(2) // inner
 
         let bag = DisposeBag()
         var r = 0
         var cnt = 0
-        bag += o.readOnly().flatMap { val in
+        bag += o.readOnly().flatMapLatest { val in
             return i.readOnly().map { val + $0 }
         }.atOnce().onValue {
             cnt += 1
@@ -1831,7 +1831,7 @@ class SignalProviderTests: XCTestCase {
         XCTAssertEqual(cnt, 7)
     }
 
-    func testFlatMapHasSourceAlt() {
+    func testFlatMapLatestHasSourceAlt() {
         let o = ReadWriteSignal(1) // outer
         let ia = ReadWriteSignal(2) // inner a
         let ib = ReadWriteSignal(3) // inner b
@@ -1839,7 +1839,7 @@ class SignalProviderTests: XCTestCase {
         let bag = DisposeBag()
         var r = 0
         var cnt = 0
-        bag += o.readOnly().flatMap { val in
+        bag += o.readOnly().flatMapLatest { val in
             return (val > 2 ? ib : ia).readOnly().map { val + $0 }
         }.atOnce().onValue {
             cnt += 1
@@ -1863,28 +1863,28 @@ class SignalProviderTests: XCTestCase {
         XCTAssertEqual(cnt, 5)
     }
 
-    func testFlatMapOnSignal() {
+    func testFlatMapLatestOnSignal() {
         let bag = DisposeBag()
         let source = ReadWriteSignal(0)
         var result = 0
 
         let signal = source.plain()
-        let s1: Signal = signal.flatMap { val in
+        let s1: Signal = signal.flatMapLatest { val in
             return Signal<Int>(just: val*2)
         }
         bag += s1.onValue { result += $0 }
 
-        let s2: FiniteSignal = signal.flatMap { val in
+        let s2: FiniteSignal = signal.flatMapLatest { val in
             return Signal<Int>(just: val*2).finite()
         }
         bag += s2.onValue { result += $0*10 }
 
-        let s3: Signal = signal.flatMap { val in
+        let s3: Signal = signal.flatMapLatest { val in
             return ReadSignal<Int>(val*2).atOnce()
         }
         bag += s3.onValue { result += $0*100 }
 
-        let s4: Signal = signal.flatMap { val in
+        let s4: Signal = signal.flatMapLatest { val in
             return ReadWriteSignal<Int>(val*2).atOnce()
         }
         bag += s4.onValue { result += $0*1000 }
@@ -1895,28 +1895,28 @@ class SignalProviderTests: XCTestCase {
         XCTAssertEqual(result, 6666)
     }
 
-    func testFlatMapOnFiniteSignal() {
+    func testFlatMapLatestOnFiniteSignal() {
         let bag = DisposeBag()
         let source = ReadWriteSignal(0)
         var result = 0
 
         let finiteSignal = source.finite()
-        let f1: FiniteSignal = finiteSignal.flatMap { val in
+        let f1: FiniteSignal = finiteSignal.flatMapLatest { val in
             return Signal<Int>(just: val*2)
         }
         bag += f1.onValue { result += $0 }
 
-        let f2: FiniteSignal = finiteSignal.flatMap { val in
+        let f2: FiniteSignal = finiteSignal.flatMapLatest { val in
             return Signal<Int>(just: val*2).finite()
         }
         bag += f2.onValue { result += $0*10 }
 
-        let f3: FiniteSignal = finiteSignal.flatMap { val in
+        let f3: FiniteSignal = finiteSignal.flatMapLatest { val in
             return ReadSignal<Int>(val*2).atOnce()
         }
         bag += f3.onValue { result += $0*100 }
 
-        let f4: FiniteSignal = finiteSignal.flatMap { val in
+        let f4: FiniteSignal = finiteSignal.flatMapLatest { val in
             return ReadWriteSignal<Int>(val*2).atOnce()
         }
         bag += f4.onValue { result += $0*1000 }
@@ -1927,28 +1927,28 @@ class SignalProviderTests: XCTestCase {
         XCTAssertEqual(result, 6666)
     }
 
-    func testFlatMapOnReadSignal() {
+    func testFlatMapLatestOnReadSignal() {
         let bag = DisposeBag()
         let source = ReadWriteSignal(0)
         var result = 0
 
         let readSignal = source.readOnly()
-        let r1: Signal = readSignal.flatMap { val in
+        let r1: Signal = readSignal.flatMapLatest { val in
             return Signal<Int>(just: val*2)
         }
         bag += r1.onValue { result += $0 }
 
-        let r2: FiniteSignal = readSignal.flatMap { val in
+        let r2: FiniteSignal = readSignal.flatMapLatest { val in
             return Signal<Int>(just: val*2).finite()
         }
         bag += r2.onValue { result += $0*10 }
 
-        let r3: ReadSignal = readSignal.flatMap { val in
+        let r3: ReadSignal = readSignal.flatMapLatest { val in
             return ReadSignal<Int>(val*2)
         }
         bag += r3.onValue { result += $0*100 }
 
-        let r4: ReadWriteSignal = readSignal.flatMap { val in
+        let r4: ReadWriteSignal = readSignal.flatMapLatest { val in
             return ReadWriteSignal<Int>(val*2)
         }
         bag += r4.onValue { result += $0*1000 }
@@ -1969,29 +1969,29 @@ class SignalProviderTests: XCTestCase {
         XCTAssertEqual(r4.value, 4)
     }
 
-    func testFlatMapOnReadWriteSignal() {
+    func testFlatMapLatestOnReadWriteSignal() {
         let bag = DisposeBag()
         let source = ReadWriteSignal(0)
         var result = 0
 
         let readWriteSignal = source
-        let rw1: Signal = readWriteSignal.flatMap { val in
+        let rw1: Signal = readWriteSignal.flatMapLatest { val in
             return Signal<Int>(just: val*2)
         }
         bag += rw1.onValue { result += $0 }
 
-        let rw2: FiniteSignal = readWriteSignal.flatMap { val in
+        let rw2: FiniteSignal = readWriteSignal.flatMapLatest { val in
             return Signal<Int>(just: val*2).finite()
         }
         bag += rw2.onValue { result += $0*10 }
 
-        let rw3: ReadSignal = readWriteSignal.flatMap { val in
+        let rw3: ReadSignal = readWriteSignal.flatMapLatest { val in
             return ReadSignal<Int>(val*2)
         }
         bag += rw3.onValue { result += $0*100 }
 
         let underlyingSignal = ReadWriteSignal(0)
-        let rw4: ReadWriteSignal = readWriteSignal.flatMap { val -> ReadWriteSignal<Int> in
+        let rw4: ReadWriteSignal = readWriteSignal.flatMapLatest { val -> ReadWriteSignal<Int> in
             return underlyingSignal
         }
         bag += rw4.onValue { result += $0*1000 }

--- a/FlowTests/SignalProviderTests.swift
+++ b/FlowTests/SignalProviderTests.swift
@@ -1769,14 +1769,14 @@ class SignalProviderTests: XCTestCase {
 
     }
 
-    func testFlatMapLatestNoSource() {
+    func testFlatMapNoSource() {
         let o = ReadWriteSignal(0) // outer
         let i = ReadWriteSignal(0) // inner
 
         let bag = DisposeBag()
         var r = 0
         var cnt = 0
-        bag += o.plain().flatMapLatest { val in
+        bag += o.plain().flatMap { val in
             return i.plain().map { val + $0 }
         }.onValue {
             cnt += 1
@@ -1800,14 +1800,14 @@ class SignalProviderTests: XCTestCase {
         XCTAssertEqual(cnt, 3)
     }
 
-    func testFlatMapLatestHasSource() {
+    func testFlatMapHasSource() {
         let o = ReadWriteSignal(1) // outer
         let i = ReadWriteSignal(2) // inner
 
         let bag = DisposeBag()
         var r = 0
         var cnt = 0
-        bag += o.readOnly().flatMapLatest { val in
+        bag += o.readOnly().flatMap { val in
             return i.readOnly().map { val + $0 }
         }.atOnce().onValue {
             cnt += 1
@@ -1831,7 +1831,7 @@ class SignalProviderTests: XCTestCase {
         XCTAssertEqual(cnt, 7)
     }
 
-    func testFlatMapLatestHasSourceAlt() {
+    func testFlatMapHasSourceAlt() {
         let o = ReadWriteSignal(1) // outer
         let ia = ReadWriteSignal(2) // inner a
         let ib = ReadWriteSignal(3) // inner b
@@ -1839,7 +1839,7 @@ class SignalProviderTests: XCTestCase {
         let bag = DisposeBag()
         var r = 0
         var cnt = 0
-        bag += o.readOnly().flatMapLatest { val in
+        bag += o.readOnly().flatMap { val in
             return (val > 2 ? ib : ia).readOnly().map { val + $0 }
         }.atOnce().onValue {
             cnt += 1
@@ -1861,6 +1861,178 @@ class SignalProviderTests: XCTestCase {
         XCTAssertEqual(r, 3 + 5)
 
         XCTAssertEqual(cnt, 5)
+    }
+
+    func testFlatMapOnSignal() {
+        let bag = DisposeBag()
+        let source = ReadWriteSignal(0)
+        var result = 0
+
+        let signal = source.plain()
+        let s1: Signal = signal.flatMap { val in
+            return Signal<Int>(just: val*2)
+        }
+        bag += s1.onValue { result += $0 }
+
+        let s2: FiniteSignal = signal.flatMap { val in
+            return Signal<Int>(just: val*2).finite()
+        }
+        bag += s2.onValue { result += $0*10 }
+
+        let s3: Signal = signal.flatMap { val in
+            return ReadSignal<Int>(val*2).atOnce()
+        }
+        bag += s3.onValue { result += $0*100 }
+
+        let s4: Signal = signal.flatMap { val in
+            return ReadWriteSignal<Int>(val*2).atOnce()
+        }
+        bag += s4.onValue { result += $0*1000 }
+
+        source.value = 1
+        XCTAssertEqual(result, 2222)
+        source.value = 2
+        XCTAssertEqual(result, 6666)
+    }
+
+    func testFlatMapOnFiniteSignal() {
+        let bag = DisposeBag()
+        let source = ReadWriteSignal(0)
+        var result = 0
+
+        let finiteSignal = source.finite()
+        let f1: FiniteSignal = finiteSignal.flatMap { val in
+            return Signal<Int>(just: val*2)
+        }
+        bag += f1.onValue { result += $0 }
+
+        let f2: FiniteSignal = finiteSignal.flatMap { val in
+            return Signal<Int>(just: val*2).finite()
+        }
+        bag += f2.onValue { result += $0*10 }
+
+        let f3: FiniteSignal = finiteSignal.flatMap { val in
+            return ReadSignal<Int>(val*2).atOnce()
+        }
+        bag += f3.onValue { result += $0*100 }
+
+        let f4: FiniteSignal = finiteSignal.flatMap { val in
+            return ReadWriteSignal<Int>(val*2).atOnce()
+        }
+        bag += f4.onValue { result += $0*1000 }
+
+        source.value = 1
+        XCTAssertEqual(result, 2222)
+        source.value = 2
+        XCTAssertEqual(result, 6666)
+    }
+
+    func testFlatMapOnReadSignal() {
+        let bag = DisposeBag()
+        let source = ReadWriteSignal(0)
+        var result = 0
+
+        let readSignal = source.readOnly()
+        let r1: Signal = readSignal.flatMap { val in
+            return Signal<Int>(just: val*2)
+        }
+        bag += r1.onValue { result += $0 }
+
+        let r2: FiniteSignal = readSignal.flatMap { val in
+            return Signal<Int>(just: val*2).finite()
+        }
+        bag += r2.onValue { result += $0*10 }
+
+        let r3: ReadSignal = readSignal.flatMap { val in
+            return ReadSignal<Int>(val*2)
+        }
+        bag += r3.onValue { result += $0*100 }
+
+        let r4: ReadWriteSignal = readSignal.flatMap { val in
+            return ReadWriteSignal<Int>(val*2)
+        }
+        bag += r4.onValue { result += $0*1000 }
+
+        XCTAssertEqual(r3.value, 0)
+        XCTAssertEqual(r4.value, 0)
+
+        source.value = 1
+
+        XCTAssertEqual(result, 2222)
+        XCTAssertEqual(r3.value, 2)
+        XCTAssertEqual(r4.value, 2)
+
+        source.value = 2
+
+        XCTAssertEqual(result, 6666)
+        XCTAssertEqual(r3.value, 4)
+        XCTAssertEqual(r4.value, 4)
+    }
+
+    func testFlatMapOnReadWriteSignal() {
+        let bag = DisposeBag()
+        let source = ReadWriteSignal(0)
+        var result = 0
+
+        let readWriteSignal = source
+        let rw1: Signal = readWriteSignal.flatMap { val in
+            return Signal<Int>(just: val*2)
+        }
+        bag += rw1.onValue { result += $0 }
+
+        let rw2: FiniteSignal = readWriteSignal.flatMap { val in
+            return Signal<Int>(just: val*2).finite()
+        }
+        bag += rw2.onValue { result += $0*10 }
+
+        let rw3: ReadSignal = readWriteSignal.flatMap { val in
+            return ReadSignal<Int>(val*2)
+        }
+        bag += rw3.onValue { result += $0*100 }
+
+        let underlyingSignal = ReadWriteSignal(0)
+        let rw4: ReadWriteSignal = readWriteSignal.flatMap { val -> ReadWriteSignal<Int> in
+            return underlyingSignal
+        }
+        bag += rw4.onValue { result += $0*1000 }
+
+        XCTAssertEqual(rw3.value, 0)
+        XCTAssertEqual(rw4.value, 0)
+
+        underlyingSignal.value = 2
+        XCTAssertEqual(result, 2000)
+        source.value = 1
+
+        XCTAssertEqual(result, 4222)
+        XCTAssertEqual(rw3.value, 2)
+        XCTAssertEqual(rw4.value, 2)
+        XCTAssertEqual(underlyingSignal.value, 2)
+
+        source.value = 2
+
+        XCTAssertEqual(result, 6666)
+        XCTAssertEqual(rw3.value, 4)
+        XCTAssertEqual(rw4.value, 2)
+        XCTAssertEqual(underlyingSignal.value, 2)
+
+        result = 0
+        rw4.value = 1
+        XCTAssertEqual(rw4.value, 1)
+        XCTAssertEqual(underlyingSignal.value, 1)
+        XCTAssertEqual(result, 1000)
+
+        rw4.value = 2
+        XCTAssertEqual(rw4.value, 2)
+        XCTAssertEqual(underlyingSignal.value, 2)
+        XCTAssertEqual(result, 3000)
+
+        bag.dispose()
+
+        result = 0
+        rw4.value = 1
+        XCTAssertEqual(rw4.value, 1)
+        XCTAssertEqual(underlyingSignal.value, 1)
+        XCTAssertEqual(result, 0)
     }
 
     #if os(iOS)


### PR DESCRIPTION
This PR updates `flatMapLatest` to be more flexible with mixing of signal kinds.

Background:

A common use of `flatMapLatest` is to map signals from some kind of service where the service might change or not always be available.

```swift
extension Service {
  var signal: Signal<T>
}

let serviceSignal: ReadSignal<Service> 

let serviceSignal: Signal = serviceSignal.flatMapLatest { service in
  return service.signal
}
```

But the above won't compile as flatMapLatest currently expect both `signal` and the signal returned from `transform` to be the same kind of signal (same `Kind`).

To work around this we need to make `signal` plain and add code such as `atOnce()` to make sure it trigger the current value:

```swift
let serviceSignal: Signal = serviceSignal.atOnce().plain().flatMapLatest { service in
  return service.signal
}
```

Similarly if we use other signals of other kinds:

```swift
extension Service {
  let finiteSignal: FiniteSignal<T>
  let readSignal: ReadSignal<T>
  let readWriteSignal: ReadWriteSignal<T>
}
```

The kind of these signals will often be lost using `flatMapLatest`. 

By combining the four available signal kinds for our signal and transform result, we would would expect the returned types to be:

```swift
let source = ReadWriteSignal(0)

let signal: Signal = source.plain()
let s1: Signal = signal.flatMapLatest { val in
    return Signal<Int>()
} // OK
let s2: FiniteSignal = signal.flatMapLatest { val in
    return FiniteSignal<Int>()
} // Compiler Error: requires self and returned signal to be of same type
let s3: Signal = signal.flatMapLatest { val in
    return ReadSignal<Int>(2)
} // Compiler Error: requires self and returned signal to be of same type
let s4: Signal = signal.flatMapLatest { val in
    return ReadWriteSignal<Int>(3)
} // Compiler Error: requires self and returned signal to be of same type

let finiteSignal: FiniteSignal = source.finite()
let f1: FiniteSignal = finiteSignal.flatMapLatest { val in
    return Signal<Int>()
} // Compiler Error: requires self and returned signal to be of same type
let f2: FiniteSignal = finiteSignal.flatMapLatest { val in
    return FiniteSignal<Int>()
} // OK
let f3: FiniteSignal = finiteSignal.flatMapLatest { val in
    return ReadSignal<Int>(2)
} // Compiler Error: requires self and returned signal to be of same type
let f4: FiniteSignal = finiteSignal.flatMapLatest { val in
    return ReadWriteSignal<Int>(3)
} // Compiler Error: requires self and returned signal to be of same type

let readSignal: ReadSignal = source.readOnly()
let r1: Signal = readSignal.flatMapLatest { val in
    return Signal<Int>()
} // Compiler Error: requires self and returned signal to be of same type
let r2: FiniteSignal = readSignal.flatMapLatest { val in
    return FiniteSignal<Int>()
} // Compiler Error: requires self and returned signal to be of same type
let r3: ReadSignal = readSignal.flatMapLatest { val in
    return ReadSignal<Int>(2)
} // OK
let r4: ReadWriteSignal = readSignal.flatMapLatest { val in
    return ReadWriteSignal<Int>(3)
} // Compiler Error: returned signal can't be of type ReadWriteSignal

let readWriteSignal: ReadWriteSignal = source
let rw1: Signal = readWriteSignal.flatMapLatest { val in
    return Signal<Int>()
} // Compiler Error: requires self and returned signal to be of same type
let rw2: FiniteSignal = readWriteSignal.flatMapLatest { val in
    return FiniteSignal<Int>()
} // Compiler Error: requires self and returned signal to be of same type
let rw3: ReadSignal = readWriteSignal.flatMapLatest { val in
    return ReadSignal<Int>(2)
} // OK
let rw4: ReadWriteSignal = readWriteSignal.flatMapLatest { val in
    return ReadWriteSignal<Int>(3)
} // Compiler Error: requires self and returned signal to be of same type
```

I suggest we fix this by replacing the current `flatMapLatest` with three versions of `flatMapLatest`:

```swift
extension SignalProvider where Self.Kind == Flow.Plain {
    public func flatMap<K, T>(on scheduler: Flow.Scheduler = default, _ transform: @escaping (Self.Value) -> Flow.CoreSignal<K, T>) -> Flow.CoreSignal<K.DropReadWrite, T> where K : SignalKind
}

extension SignalProvider where Self.Kind == Flow.Finite {
    public func flatMap<K, T>(on scheduler: Flow.Scheduler = default, _ transform: @escaping (Self.Value) -> Flow.CoreSignal<K, T>) -> Flow.CoreSignal<Self.Kind.DropReadWrite, T> where K : SignalKind
}

extension SignalProvider where Self.Kind.DropWrite == Flow.Read {
    public func flatMap<K, T>(on scheduler: Flow.Scheduler = default, _ transform: @escaping (Self.Value) -> Flow.CoreSignal<K, T>) -> Flow.CoreSignal<K, T> where K : SignalKind
}
```

It seems this change is backward compatible as this change mostly opens up more usages. 
I have tested this in our code having about 24 instance of `flatMapLatest` and the compiler did not complain. The original tests in Flow passed gallantly as well.