### PR TITLE
Added `Signal.toogle()`  method for read-write boolean signals.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 1.4
+
 - Updated the `Signal.flatMapLatest()` transformation to allow more flexible mixing of signal types between `self` and the signal returned from `transform`.
+- Added `Signal.toogle()`  method for read-write boolean signals.
 
 # 1.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 1.4
 
 - Updated the `Signal.flatMapLatest()` transformation to allow more flexible mixing of signal types between `self` and the signal returned from `transform`.
-- Added `Signal.toogle()`  method for read-write boolean signals.
+- Added `Signal.toogle()` method for read-write boolean signals.
 
 # 1.3.1
 

--- a/Flow/Signal+Listeners.swift
+++ b/Flow/Signal+Listeners.swift
@@ -142,7 +142,6 @@ public extension SignalProvider where Value == () {
     /// Start listening on values and toggle `signal`'s value for every recieved event.
     /// - Returns: A disposable that will stop listening on values when being disposed.
     func toggle<ReadWriteSignal: SignalProvider>(_ signal: ReadWriteSignal) -> Disposable where ReadWriteSignal.Value == Bool, ReadWriteSignal.Kind == ReadWrite {
-        let signal = signal.providedSignal
-        return onValue { signal.value = !signal.value }
+        return onValue(signal.providedSignal.toggle)
     }
 }

--- a/Flow/Signal+Transforms.swift
+++ b/Flow/Signal+Transforms.swift
@@ -801,6 +801,13 @@ public extension SignalProvider where Value == Bool {
     }
 }
 
+public extension SignalProvider where Kind == ReadWrite, Value == Bool {
+    /// Will update `value` to `!value´.
+    func toggle() {
+        return value = !value
+    }
+}
+
 public extension SignalProvider where Value: Equatable {
     /// Returns a new signal discarding values if comparing the same with the preceeding value.
     ///


### PR DESCRIPTION
Allowing you to write code such as:

```swift
let enabled: ReadWriteSignal<Bool>
bag += button.onValue(enabled.toggle)
```