### PR TITLE
Added `willWrite()` and `didWrite()` transformations to read write si…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Updated the `Signal.flatMapLatest()` transformation to allow more flexible mixing of signal types between `self` and the signal returned from `transform`.
 - Added `Signal.toogle()` method for read-write boolean signals.
+- Added `willWrite()` and `didWrite()` transformations to read write signal.
 
 # 1.3.1
 

--- a/Flow/ReadWriteSignal.swift
+++ b/Flow/ReadWriteSignal.swift
@@ -75,6 +75,26 @@ public extension SignalProvider where Kind == ReadWrite {
     }
 }
 
+public extension SignalProvider where Kind == ReadWrite {
+    /// The provided `callback` will be called with the new value just before it is being set.
+    func willWrite(_ callback: @escaping (Value) -> Void) -> ReadWriteSignal<Value> {
+        let signal = providedSignal
+        return CoreSignal(setValue: { value in
+            callback(value)
+            signal.value = value
+        }, onEventType: signal.onEventType)
+    }
+
+    /// The provided `callback` will be called with the new value just after it has been set.
+    func didWrite(_ callback: @escaping (Value) -> Void) -> ReadWriteSignal<Value> {
+        let signal = providedSignal
+        return CoreSignal(setValue: { value in
+            signal.value = value
+            callback(value)
+        }, onEventType: signal.onEventType)
+    }
+}
+
 private var propertySetterKey = false
 
 internal extension SignalProvider {

--- a/FlowTests/SignalProviderTests.swift
+++ b/FlowTests/SignalProviderTests.swift
@@ -2354,6 +2354,27 @@ class SignalProviderStressTests: XCTestCase {
         }
     }
 
+    func testWillDidWrite() {
+        var result = [Int]()
+        let s = ReadWriteSignal(0).willWrite { value in
+            result.append(value * 2)
+        }.didWrite { value in
+            result.append(value * 3)
+        }
+
+        XCTAssertEqual(result, [])
+        s.value = 2
+        XCTAssertEqual(result, [2*2, 2*3])
+
+        let bag = DisposeBag()
+        bag += s.onValue { value in
+            result.append(value * 5)
+        }
+
+        s.value = 3
+        XCTAssertEqual(result, [2*2, 2*3, 3*2, 3*5, 3*3])
+    }
+
     #if DEBUG
     func testDebounceSimulatedDelay() {
         runTest(timeout: 2) { bag in


### PR DESCRIPTION
…gnal.

This is useful if you are not the consumer of a read-write signal nor the producer and like to perform some action when the value is written to, this is useful. For example:

```swift
struct ViewModel {
   var enabled: ReadWriteSignal<Bool>
}

protocol Service {
   var enabled: ReadWriteSignal<Bool>
}

extension ViewModel {
  init(service: Service) {
    enabled = service.enabled.didWrite { value in
       // Perhaps call analytics here?
    }
  }
}
```
