### PR TITLE
Backtracking the addition of willWrite as having a scheduler can't no…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Updated the `Signal.flatMapLatest()` transformation to allow more flexible mixing of signal types between `self` and the signal returned from `transform`.
 - Added `Signal.toogle()` method for read-write boolean signals.
-- Added `willWrite()` and `didWrite()` transformations to read write signal.
+- Added `didWrite()` transformations to read-write signals.
 - Added `UIControl` `valueChanged` that will signal with the latest value when the control event `.valueChanged` is signaled.
 
 # 1.3.1

--- a/Flow/ReadWriteSignal.swift
+++ b/Flow/ReadWriteSignal.swift
@@ -76,15 +76,6 @@ public extension SignalProvider where Kind == ReadWrite {
 }
 
 public extension SignalProvider where Kind == ReadWrite {
-    /// The provided `callback` will be called with the new value just before it is being set.
-    func willWrite(on scheduler: Scheduler = .current, _ callback: @escaping (Value) -> Void) -> ReadWriteSignal<Value> {
-        let signal = providedSignal
-        return CoreSignal(setValue: { value in
-            scheduler.async { callback(value) }
-            signal.value = value
-        }, onEventType: signal.onEventType)
-    }
-
     /// The provided `callback` will be called with the new value just after it has been set.
     func didWrite(on scheduler: Scheduler = .current, _ callback: @escaping (Value) -> Void) -> ReadWriteSignal<Value> {
         let signal = providedSignal

--- a/FlowTests/SignalProviderTests.swift
+++ b/FlowTests/SignalProviderTests.swift
@@ -2356,15 +2356,13 @@ class SignalProviderStressTests: XCTestCase {
 
     func testWillDidWrite() {
         var result = [Int]()
-        let s = ReadWriteSignal(0).willWrite { value in
-            result.append(value * 2)
-        }.didWrite { value in
+        let s = ReadWriteSignal(0).didWrite { value in
             result.append(value * 3)
         }
 
         XCTAssertEqual(result, [])
         s.value = 2
-        XCTAssertEqual(result, [2*2, 2*3])
+        XCTAssertEqual(result, [2*3])
 
         let bag = DisposeBag()
         bag += s.onValue { value in
@@ -2372,7 +2370,7 @@ class SignalProviderStressTests: XCTestCase {
         }
 
         s.value = 3
-        XCTAssertEqual(result, [2*2, 2*3, 3*2, 3*5, 3*3])
+        XCTAssertEqual(result, [2*3, 3*5, 3*3])
     }
 
     #if DEBUG


### PR DESCRIPTION
… longer guarantee that the callback is called before the value is set. In general reactive programming notifies when something has happened not before, so I think adding willWrite was not the best idea anyway.