### PR TITLE
onErrorRepeat - Delay fix

### DIFF
--- a/Flow/Future+Additions.swift
+++ b/Flow/Future+Additions.swift
@@ -306,7 +306,7 @@ public extension Future {
     @discardableResult
     func onErrorRepeat(on scheduler: Scheduler = .current, delayBetweenRepetitions delay: TimeInterval? = nil, maxRepetitions: Int? = nil, when predicate: @escaping (Error) -> Bool = { _ in true }) -> Future {
         return onErrorRepeat(on: scheduler, maxRepetitions: maxRepetitions) { error in
-            Future<Bool>(predicate(error))
+            Future<Bool>(predicate(error)).delay(by: delay)
         }
     }
 

--- a/FlowTests/FutureRepeatTests.swift
+++ b/FlowTests/FutureRepeatTests.swift
@@ -261,11 +261,13 @@ class FutureRepeatTests: FutureTest {
     func testRetryOnError() {
         testFuture(timeout: 5) { () -> Future<()> in
             let e = expectation(description: "Sums up")
+            let start = Date()
             var sum = 0
             return Future(error: TestError.fatal).delay(by: 0.1).onError { _ in
                 sum += 1
-            }.onErrorRepeat(delayBetweenRepetitions: 0.1, maxRepetitions: 3).onError { _ in
+            }.onErrorRepeat(delayBetweenRepetitions: 0.5, maxRepetitions: 3).onError { _ in
                 XCTAssertEqual(sum, 4)
+                XCTAssert(Date().timeIntervalSince(start) > 1.5)
                 e.fulfill()
             }
         }


### PR DESCRIPTION
Fixes a problem where `onErrorRepeat` would not respect the specified delay interval.

Modified the test `testRetryOnError` to catch this bug.