### PR TITLE
Adds flatMapLatestIgnoringError

### DIFF
--- a/Flow.xcodeproj/project.pbxproj
+++ b/Flow.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		21E1D41C1D9502A300A91CA0 /* Future+Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E1D41B1D9502A300A91CA0 /* Future+Signal.swift */; };
 		7484FA6B212D9E930076FD3E /* Signal+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7484FA6A212D9E930076FD3E /* Signal+Debug.swift */; };
 		8E890FC106FB7A89BD1727CC /* EitherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E890194B06CBB3311E44757 /* EitherTests.swift */; };
+		ED86B77A2186F77C0094EA52 /* SignalProvider+Finite.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED86B7792186F77C0094EA52 /* SignalProvider+Finite.swift */; };
 		F610ABAE1D91743500A161AB /* Future+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F610ABA71D91743500A161AB /* Future+Additions.swift */; };
 		F610ABB01D91743500A161AB /* FutureQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = F610ABA91D91743500A161AB /* FutureQueue.swift */; };
 		F610ABB21D91743500A161AB /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = F610ABAB1D91743500A161AB /* Result.swift */; };
@@ -83,6 +84,7 @@
 		21E1D41B1D9502A300A91CA0 /* Future+Signal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Future+Signal.swift"; path = "Flow/Future+Signal.swift"; sourceTree = SOURCE_ROOT; };
 		7484FA6A212D9E930076FD3E /* Signal+Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Signal+Debug.swift"; path = "Flow/Signal+Debug.swift"; sourceTree = "<group>"; };
 		8E890194B06CBB3311E44757 /* EitherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EitherTests.swift; sourceTree = "<group>"; };
+		ED86B7792186F77C0094EA52 /* SignalProvider+Finite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SignalProvider+Finite.swift"; sourceTree = "<group>"; };
 		F610ABA61D91743500A161AB /* Future.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Future.swift; path = Flow/Future.swift; sourceTree = SOURCE_ROOT; };
 		F610ABA71D91743500A161AB /* Future+Additions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Future+Additions.swift"; path = "Flow/Future+Additions.swift"; sourceTree = SOURCE_ROOT; };
 		F610ABA91D91743500A161AB /* FutureQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FutureQueue.swift; path = Flow/FutureQueue.swift; sourceTree = SOURCE_ROOT; };
@@ -220,6 +222,7 @@
 				F68EF3521FD58FC70001129C /* Event.swift */,
 				F6B6A6642056B2CA00B9FC9D /* EventType.swift */,
 				7484FA6A212D9E930076FD3E /* Signal+Debug.swift */,
+				ED86B7792186F77C0094EA52 /* SignalProvider+Finite.swift */,
 			);
 			name = Signal;
 			sourceTree = "<group>";
@@ -451,6 +454,7 @@
 				F6B6A6612056AF0300B9FC9D /* Signal.swift in Sources */,
 				F6AD20571E2FB5320082CF27 /* UIControls+Extensions.swift in Sources */,
 				F6FF03E21D926AC300B93771 /* Signal+Transforms.swift in Sources */,
+				ED86B77A2186F77C0094EA52 /* SignalProvider+Finite.swift in Sources */,
 				F6FF03E31D926AC300B93771 /* Signal+KeyValueObserving.swift in Sources */,
 				F68EF3551FD58FD20001129C /* UIView+Signal.swift in Sources */,
 				F6B6A6632056AF4300B9FC9D /* ReadWriteSignal.swift in Sources */,

--- a/SignalProvider+Finite.swift
+++ b/SignalProvider+Finite.swift
@@ -1,0 +1,45 @@
+//
+//  SignalProvider+Finite.swift
+//  Flow
+//
+//  Created by Vasil Nunev on 2018-10-29.
+//  Copyright © 2018 iZettle. All rights reserved.
+//
+
+import Foundation
+
+public extension SignalProvider where Kind == Finite {
+    /// Returns a new signal forwarding the values from the signal returned from `transform`, ignoring any errors.
+    ///
+    ///     ---a--------b------------|
+    ///        |        |
+    ///     +-------------------------+
+    ///     | flatMapLatest() - plain |
+    ///     +-------------------------+
+    ///     ---s1-------s2-----------|
+    ///        |        |
+    ///     -----1---2-----1---2--3--|
+    ///
+    ///     0)--------a---------b----------|
+    ///               |         |
+    ///     +----------------------------+
+    ///     | flatMapLatest() - readable |
+    ///     +----------------------------+
+    ///     s0)-------s1--------s2---------|
+    ///               |         |
+    ///     0)--1--2--0--1--2---0--1--2----|
+    ///
+    /// - Note: If `self` signals a value, any a previous signal returned from `transform` will be disposed.
+    /// - Note: If `self` and `other` are both readable their current values will be used as initial values.
+    /// - Note: If either `self` of the signal returned from `transform` are terminated, the returned signal will terminated as well.
+    func flatMapLatestIgnoringError<V>(on scheduler: Scheduler = .current, _ transform: @escaping (Value) -> FiniteSignal<V>) -> FiniteSignal<V> {
+        return flatMapLatest(on: scheduler) { value in
+            transform(value).neverEnds()
+        }
+    }
+
+    /// Returns a new finite signal that never terminates.
+    func neverEnds() -> FiniteSignal<Value> {
+        return self.plain().finite()
+    }
+}


### PR DESCRIPTION
### What
It has come to our attention that when `Flow` is used with `Presentation` and the presentation has a flow of view controllers, and you want to use `flatMapLatest`, when the user click the "Back" button the bag from the previous View Controllers will be disposed.

### Solution
Introduce a `flatMapLatestIgnoringError` that won't dispose the previous bags when the presentation is dismissed. This is also related to https://github.com/iZettle/Presentation/pull/20#discussion_r228743254

To do:

- [x] Introduce `flatMapLatestIgnoringError`

- [ ] Unit Tests?