### PR TITLE
Add support for tvOS

### DIFF
--- a/Flow.xcodeproj/project.pbxproj
+++ b/Flow.xcodeproj/project.pbxproj
@@ -677,8 +677,9 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = "";
-				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos";
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos appletvos appletvsimulator";
 				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3";
 			};
 			name = Debug;
 		};
@@ -691,8 +692,9 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = "";
-				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos";
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos appletvos appletvsimulator";
 				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3";
 			};
 			name = Release;
 		};

--- a/Flow.xcodeproj/project.pbxproj
+++ b/Flow.xcodeproj/project.pbxproj
@@ -636,8 +636,9 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = "";
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvos appletvsimulator";
 				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3";
 			};
 			name = Debug;
 		};
@@ -661,8 +662,9 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = "";
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvos appletvsimulator";
 				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3";
 			};
 			name = Release;
 		};

--- a/Flow/UIControls+Extensions.swift
+++ b/Flow/UIControls+Extensions.swift
@@ -62,6 +62,21 @@ extension UIButton: SignalProvider {
     }
 }
 
+extension UISegmentedControl: SignalProvider {
+    public var providedSignal: ReadWriteSignal<Int> {
+        return signal(for: .valueChanged, keyPath: \.selectedSegmentIndex)
+            .distinct() // KVO seems to trigger when tapping as well, even when tapping selected.
+    }
+}
+
+extension UIPageControl: SignalProvider {
+    public var providedSignal: ReadWriteSignal<Int> {
+        return signal(for: .valueChanged, keyPath: \.currentPage)
+    }
+}
+
+#if !os(tvOS)
+
 extension UISwitch: SignalProvider {
     public var providedSignal: ReadWriteSignal<Bool> {
         return signal(for: .valueChanged, keyPath: \.isOn)
@@ -71,13 +86,6 @@ extension UISwitch: SignalProvider {
 extension UISlider: SignalProvider {
     public var providedSignal: ReadWriteSignal<Float> {
         return signal(for: .valueChanged, keyPath: \.value).distinct()
-    }
-}
-
-extension UISegmentedControl: SignalProvider {
-    public var providedSignal: ReadWriteSignal<Int> {
-        return signal(for: .valueChanged, keyPath: \.selectedSegmentIndex)
-            .distinct() // KVO seems to trigger when tapping as well, even when tapping selected.
     }
 }
 
@@ -114,11 +122,7 @@ extension UIDatePicker: SignalProvider {
     }
 }
 
-extension UIPageControl: SignalProvider {
-    public var providedSignal: ReadWriteSignal<Int> {
-        return signal(for: .valueChanged, keyPath: \.currentPage)
-    }
-}
+#endif
 
 extension UIBarItem: Enablable {}
 
@@ -195,10 +199,14 @@ public extension UITextField {
     }
 }
 
+#if !os(tvOS)
+
 /// Returns a signal that will signal on orientation changes.
 public var orientationSignal: ReadSignal<UIInterfaceOrientation> {
     return NotificationCenter.default.signal(forName: .UIApplicationDidChangeStatusBarOrientation).map { _ in UIApplication.shared.statusBarOrientation }.readable(capturing: UIApplication.shared.statusBarOrientation)
 }
+
+#endif
 
 private extension UITextField {
     class TextFieldDelegate: NSObject, UITextFieldDelegate {

--- a/Flow/UIView+EditingMenu.swift
+++ b/Flow/UIView+EditingMenu.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 iZettle. All rights reserved.
 //
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(tvOS)
 
 import UIKit
 

--- a/FlowFramework.podspec
+++ b/FlowFramework.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
 
   s.osx.deployment_target = "10.11"
   s.ios.deployment_target = "9.0"
+  s.tvos.deployment_target = "9.0"
 
   s.source       = { :git => "https://github.com/iZettle/Flow.git", :tag => "#{s.version}" }
   s.source_files = "Flow/*.{swift}"


### PR DESCRIPTION
### What?
I've been attempting to extend the single-target framework for tvOS-support, but there is something still not working (something missing in the Build Settings I assume). I'm looking for input, and to see if this build working frameworks on other machines.

### Why?
We currently show in the README that we support tvOS, but that's not true. It should also be a quite straightforward extension, if this would work.

### Discussion
Does anyone know what's preventing this from building correctly? The .framework file I get is empty when I import it into another project (i.e. no classes or APIs are exposed).