### PR TITLE
Add UIViewController lifecycle signals

### DIFF
--- a/Flow.xcodeproj/project.pbxproj
+++ b/Flow.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		21E1D41C1D9502A300A91CA0 /* Future+Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E1D41B1D9502A300A91CA0 /* Future+Signal.swift */; };
 		7484FA6B212D9E930076FD3E /* Signal+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7484FA6A212D9E930076FD3E /* Signal+Debug.swift */; };
 		8E890FC106FB7A89BD1727CC /* EitherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E890194B06CBB3311E44757 /* EitherTests.swift */; };
+		CD1B40012190C92000643FF6 /* UIViewController+Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1B40002190C92000643FF6 /* UIViewController+Signal.swift */; };
+		CD1B40032190CCF100643FF6 /* UIViewControllerSignalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1B40022190CCF100643FF6 /* UIViewControllerSignalTests.swift */; };
 		F610ABAE1D91743500A161AB /* Future+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F610ABA71D91743500A161AB /* Future+Additions.swift */; };
 		F610ABB01D91743500A161AB /* FutureQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = F610ABA91D91743500A161AB /* FutureQueue.swift */; };
 		F610ABB21D91743500A161AB /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = F610ABAB1D91743500A161AB /* Result.swift */; };
@@ -83,6 +85,8 @@
 		21E1D41B1D9502A300A91CA0 /* Future+Signal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Future+Signal.swift"; path = "Flow/Future+Signal.swift"; sourceTree = SOURCE_ROOT; };
 		7484FA6A212D9E930076FD3E /* Signal+Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Signal+Debug.swift"; path = "Flow/Signal+Debug.swift"; sourceTree = "<group>"; };
 		8E890194B06CBB3311E44757 /* EitherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EitherTests.swift; sourceTree = "<group>"; };
+		CD1B40002190C92000643FF6 /* UIViewController+Signal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIViewController+Signal.swift"; path = "Flow/UIViewController+Signal.swift"; sourceTree = "<group>"; };
+		CD1B40022190CCF100643FF6 /* UIViewControllerSignalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIViewControllerSignalTests.swift; path = FlowTests/UIViewControllerSignalTests.swift; sourceTree = "<group>"; };
 		F610ABA61D91743500A161AB /* Future.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Future.swift; path = Flow/Future.swift; sourceTree = SOURCE_ROOT; };
 		F610ABA71D91743500A161AB /* Future+Additions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Future+Additions.swift"; path = "Flow/Future+Additions.swift"; sourceTree = SOURCE_ROOT; };
 		F610ABA91D91743500A161AB /* FutureQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FutureQueue.swift; path = Flow/FutureQueue.swift; sourceTree = SOURCE_ROOT; };
@@ -230,6 +234,7 @@
 				F6AD20561E2FB5320082CF27 /* UIControls+Extensions.swift */,
 				F68EF3541FD58FD20001129C /* UIView+Signal.swift */,
 				F66835CE2091B887002D2676 /* UIView+EditingMenu.swift */,
+				CD1B40002190C92000643FF6 /* UIViewController+Signal.swift */,
 				F667FCD7200604570014DA7D /* Enablable.swift */,
 				F6FF03DB1D926AC300B93771 /* TargetActionable.swift */,
 				F6E752302099B60A0092EDAA /* HasEventListeners.swift */,
@@ -301,6 +306,7 @@
 				215DEF351DEC367E00CEB724 /* RecursiveTests.swift */,
 				F6C0FED1202B44360076B877 /* DelegateTests.swift */,
 				F66835D32091C29C002D2676 /* UIViewSignalTests.swift */,
+				CD1B40022190CCF100643FF6 /* UIViewControllerSignalTests.swift */,
 				F6F679A220A966D1004C7AA7 /* EventListenerTests.swift */,
 				8E890194B06CBB3311E44757 /* EitherTests.swift */,
 			);
@@ -442,6 +448,7 @@
 				F6462A401EFA5065007E2198 /* Signal+Construction.swift in Sources */,
 				F6B6A65F2056AEA400B9FC9D /* ReadSignal.swift in Sources */,
 				F6FF03E71D926AC300B93771 /* Utilities.swift in Sources */,
+				CD1B40012190C92000643FF6 /* UIViewController+Signal.swift in Sources */,
 				F66C47A720077B2500333410 /* Signal+Combiners.swift in Sources */,
 				F662C0A71FDFDEB300E5F869 /* Signal+Scheduling.swift in Sources */,
 				F6FF03E41D926AC300B93771 /* CoreSignal.swift in Sources */,
@@ -487,6 +494,7 @@
 				F610ABC01D91747000A161AB /* FutureSplitTests.swift in Sources */,
 				215DEF371DEC368700CEB724 /* RecursiveTests.swift in Sources */,
 				F66835D42091C29C002D2676 /* UIViewSignalTests.swift in Sources */,
+				CD1B40032190CCF100643FF6 /* UIViewControllerSignalTests.swift in Sources */,
 				F6C0FED2202B44360076B877 /* DelegateTests.swift in Sources */,
 				F6F679A320A966D1004C7AA7 /* EventListenerTests.swift in Sources */,
 				F610ABBD1D91747000A161AB /* FutureQueueTests.swift in Sources */,

--- a/Flow/UIViewController+Signal.swift
+++ b/Flow/UIViewController+Signal.swift
@@ -1,0 +1,135 @@
+//
+//  UIViewController+Signals.swift
+//  Flow
+//
+//  Created by João D. Moreira on 2018-11-02.
+//  Copyright © 2018 iZettle. All rights reserved.
+//
+
+#if canImport(UIKit)
+
+import UIKit
+
+public extension UIViewController {
+    var viewDidLoadSignal: Signal<Void> {
+        return Signal(callbacker: callbackers.viewDidLoad)
+    }
+
+    var viewWillAppearSignal: Signal<Bool> {
+        return Signal(callbacker: callbackers.viewWillAppear)
+    }
+
+    var viewDidAppearSignal: Signal<Bool> {
+        return Signal(callbacker: callbackers.viewDidAppear)
+    }
+
+    var viewWillDisappearSignal: Signal<Bool> {
+        return Signal(callbacker: callbackers.viewWillDisappear)
+    }
+
+    var viewDidDisappearSignal: Signal<Bool> {
+        return Signal(callbacker: callbackers.viewDidDisappear)
+    }
+
+    var viewWillLayoutSubviewsSignal: Signal<Void> {
+        return Signal(callbacker: callbackers.viewWillLayoutSubviews)
+    }
+
+    var viewDidLayoutSubviewsSignal: Signal<Void> {
+        return Signal(callbacker: callbackers.viewDidLayoutSubviews)
+    }
+}
+
+/// A callbacker box used by the swizzled implementations
+private class Callbackers {
+    let viewDidLoad = Callbacker<Void>()
+    let viewWillAppear = Callbacker<Bool>()
+    let viewDidAppear = Callbacker<Bool>()
+    let viewWillDisappear = Callbacker<Bool>()
+    let viewDidDisappear = Callbacker<Bool>()
+    let viewWillLayoutSubviews = Callbacker<Void>()
+    let viewDidLayoutSubviews = Callbacker<Void>()
+}
+
+private var callbackersKey = false
+private extension UIViewController {
+    var callbackers: Callbackers {
+        let _ = UIViewController.runOnce
+
+        if let previousValue = objc_getAssociatedObject(self, &callbackersKey) as? Callbackers {
+            return previousValue
+        } else {
+            let initial = Callbackers()
+            objc_setAssociatedObject(self, &callbackersKey, initial, .OBJC_ASSOCIATION_RETAIN)
+            return initial
+        }
+    }
+}
+
+/// Swizzling of all UIViewController lifecycle methods
+private extension UIViewController {
+    static let runOnce: Void = {
+        selectorsToSwizzle.forEach { (original, swizzled) in
+            swizzle(class: UIViewController.self, original: original, swizzled: swizzled)
+        }
+    }()
+
+    static let selectorsToSwizzle: [(original: Selector, swizzled: Selector)] = [
+        (#selector(UIViewController.viewDidLoad), #selector(UIViewController._swizzled_viewDidLoad)),
+        (#selector(UIViewController.viewWillAppear(_:)), #selector(UIViewController._swizzled_viewWillAppear(_:))),
+        (#selector(UIViewController.viewDidAppear(_:)), #selector(UIViewController._swizzled_viewDidAppear(_:))),
+        (#selector(UIViewController.viewWillDisappear(_:)), #selector(UIViewController._swizzled_viewWillDisappear(_:))),
+        (#selector(UIViewController.viewDidDisappear(_:)), #selector(UIViewController._swizzled_viewDidDisappear(_:))),
+        (#selector(UIViewController.viewWillLayoutSubviews), #selector(UIViewController._swizzled_viewWillLayoutSubviews)),
+        (#selector(UIViewController.viewDidLayoutSubviews), #selector(UIViewController._swizzled_viewDidLayoutSubviews)) ]
+}
+
+private func swizzle(class aClass: AnyClass, original: Selector, swizzled: Selector) {
+    guard let original = class_getInstanceMethod(aClass, original),
+        let swizzled = class_getInstanceMethod(aClass, swizzled) else {
+            assertionFailure("Invalid selector for " +  String(describing: aClass))
+            return
+    }
+
+    method_exchangeImplementations(original, swizzled)
+}
+
+/// Swizzled method implementations
+private extension UIViewController {
+    @objc func _swizzled_viewDidLoad() {
+        self._swizzled_viewDidLoad()
+        callbackers.viewDidLoad.callAll()
+    }
+
+    @objc func _swizzled_viewWillAppear(_ animated: Bool) {
+        self._swizzled_viewWillAppear(animated)
+        callbackers.viewWillAppear.callAll(with: animated)
+    }
+
+    @objc func _swizzled_viewDidAppear(_ animated: Bool) {
+        self._swizzled_viewDidAppear(animated)
+        callbackers.viewDidAppear.callAll(with: animated)
+    }
+
+    @objc func _swizzled_viewWillDisappear(_ animated: Bool) {
+        self._swizzled_viewWillDisappear(animated)
+        callbackers.viewWillDisappear.callAll(with: animated)
+    }
+
+    @objc func _swizzled_viewDidDisappear(_ animated: Bool) {
+        self._swizzled_viewDidDisappear(animated)
+        callbackers.viewDidDisappear.callAll(with: animated)
+    }
+
+    @objc func _swizzled_viewWillLayoutSubviews() {
+        self._swizzled_viewWillLayoutSubviews()
+        callbackers.viewWillLayoutSubviews.callAll()
+    }
+
+    @objc func _swizzled_viewDidLayoutSubviews() {
+        self._swizzled_viewDidLayoutSubviews()
+        callbackers.viewDidLayoutSubviews.callAll()
+    }
+}
+
+#endif

--- a/FlowTests/UIViewControllerSignalTests.swift
+++ b/FlowTests/UIViewControllerSignalTests.swift
@@ -1,0 +1,88 @@
+//
+//  UIViewControllerSignalTests.swift
+//  Flow
+//
+//  Created by João D. Moreira on 2018-11-05.
+//  Copyright © 2018 iZettle. All rights reserved.
+//
+
+import XCTest
+import Flow
+
+#if canImport(UIKit)
+
+import UIKit
+
+class UIViewControllerSignalTests: XCTestCase {
+    let window = UIWindow()
+    let bag = DisposeBag()
+
+    func testLoadView() {
+        let viewController = UIViewController()
+
+        let expectation = self.expectation(description: "UIViewController's view didLoad")
+        bag += viewController.viewDidLoadSignal.onValue {
+            expectation.fulfill()
+        }
+
+        viewController.loadViewIfNeeded()
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func testAppearView() {
+        let navController = UINavigationController()
+        window.rootViewController = navController
+        window.isHidden = false
+
+        let viewController = UIViewController()
+
+        let viewWillAppearExpectation = self.expectation(description: "UIViewController's view will appear")
+        bag += viewController.viewWillAppearSignal.onValue { _ in
+            viewWillAppearExpectation.fulfill()
+        }
+
+        let viewDidAppearExpectation = self.expectation(description: "UIViewController's view did appear")
+        bag += viewController.viewDidAppearSignal.onValue { _ in
+            viewDidAppearExpectation.fulfill()
+            self.window.rootViewController = nil
+        }
+
+        let viewWillDisappearExpectation = self.expectation(description: "UIViewController's view will disappear")
+        bag += viewController.viewWillDisappearSignal.onValue { _ in
+            viewWillDisappearExpectation.fulfill()
+        }
+
+        let viewDidDisappearExpectation = self.expectation(description: "UIViewController's view did disappear")
+        bag += viewController.viewDidDisappearSignal.onValue { _ in
+            viewDidDisappearExpectation.fulfill()
+        }
+
+        navController.pushViewController(viewController, animated: true)
+
+        let orderedExpectations = [viewWillAppearExpectation, viewDidAppearExpectation,
+                                   viewWillDisappearExpectation, viewDidDisappearExpectation]
+        wait(for: orderedExpectations, timeout: 5, enforceOrder: true)
+    }
+
+    func testLayoutSubviews() {
+        let viewController = UIViewController()
+
+        let viewWillLayoutSubviews = self.expectation(description: "UIViewController subview will layout")
+        bag += viewController.viewWillLayoutSubviewsSignal.onValue {
+            viewWillLayoutSubviews.fulfill()
+        }
+
+        let viewDidLayoutSubviews = self.expectation(description: "UIViewController subview did layout")
+        bag += viewController.viewDidLayoutSubviewsSignal.onValue {
+            viewDidLayoutSubviews.fulfill()
+        }
+
+        viewController.view.setNeedsLayout()
+        viewController.view.layoutIfNeeded()
+
+        wait(for: [viewWillLayoutSubviews, viewDidLayoutSubviews], timeout: 5, enforceOrder: true)
+    }
+}
+
+#endif


### PR DESCRIPTION
(continued from https://github.com/iZettle/Presentation/pull/24)

Hello friends 👋
I've noticed you were discussing adding signals for the `UIViewController` lifecycles methods.
Since I already had an implementation on my hard drive, I've decided it was better to just send a pull request.

### What
Add signals to `UIViewController` so we can listen on lifecycle events.

### How
Swizzling the lifecycle methods and calling a `callbacker` that lives inside `UIViewController` as an associated object.