### PR TITLE
Bug-fix: Updates some transforms such as `toVoid()` to schedule on `.no…

### DIFF
--- a/Flow/Future+Additions.swift
+++ b/Flow/Future+Additions.swift
@@ -189,14 +189,14 @@ public extension Future {
     /// Returns a new `Future<Void>` where any success value from `self` is discarded.
     @discardableResult
     func toVoid() -> Future<Void> {
-        return map { _ in return Void() }
+        return map(on: .none) { _ in return Void() }
     }
 
     /// Returns a new future that will not cancel `self` if being canceled
     @discardableResult
     func ignoreCanceling() -> Future {
-        return Future { completion, mover in
-            mover.moveInside(self).onResult(completion)
+        return Future(on: .none) { completion, mover in
+            mover.moveInside(self).onResult(on: .none, completion)
             return NilDisposer()
         }
     }
@@ -245,7 +245,7 @@ public extension Future {
     /// - Note: A `delay` of zero will still delay calling `work`. However, passing a nil `delay` will execute `work` at once.
     @discardableResult
     func performWhile(on scheduler: Scheduler = .current, delayBy delay: TimeInterval? = nil, _ work: @escaping () -> Disposable) -> Future {
-        return Future { completion, mover in
+        return Future(on: scheduler) { completion, mover in
             let future = mover.moveInside(self)
             let bag = DisposeBag(NilDisposer()) // make non-empty
 

--- a/Flow/Future.swift
+++ b/Flow/Future.swift
@@ -311,7 +311,7 @@ public extension Future {
     @discardableResult
     func replace(with result: Result<Value>, after timeout: TimeInterval) -> Future {
         return Future(on: .none) { completion, mover in
-            let future = mover.moveInside(self).onResult(completion)
+            let future = mover.moveInside(self).onResult(on: .none, completion)
             return disposableAsync(after: timeout) {
                 future.cancel()
                 completion(result)

--- a/Flow/Signal+Transforms.swift
+++ b/Flow/Signal+Transforms.swift
@@ -11,7 +11,7 @@ import Foundation
 public extension SignalProvider {
     /// Returns a new signal where values are replaced with `()`, equivalent to `map { _ in }`.
     func toVoid() -> CoreSignal<Kind.DropWrite, ()> {
-        return map { _ in }
+        return map(on: .none) { _ in }
     }
 
     /// Returns a new signal where the values in `values` will be immediately signaled and before any other values are signaled from `self`.


### PR DESCRIPTION
…ne` instead of `.current` so these transforms won't cause a re-schedule.