### PR TITLE
Move CopyingView long press recognizer to its superview

### DIFF
--- a/Flow/UIView+EditingMenu.swift
+++ b/Flow/UIView+EditingMenu.swift
@@ -90,7 +90,7 @@ private class CopyingView: UIView {
         superview.isUserInteractionEnabled = true
         let bag = DisposeBag()
         let longPressGesture = UILongPressGestureRecognizer()
-        bag += install(longPressGesture)
+        bag += superview.install(longPressGesture)
         bag += longPressGesture.signal(forState: .began).onValue { [weak self] in
             let menu = UIMenuController.shared
             guard !menu.isMenuVisible else { return }
@@ -127,10 +127,6 @@ private class CopyingView: UIView {
     }
 
     override var canBecomeFirstResponder: Bool {
-        return true
-    }
-
-    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
         return true
     }
 }


### PR DESCRIPTION
### The bug
When observing a `UIView`'s `copySignal` it inserts an instance of `CopyingView` as a subview to catch long presses, but this can currently block other touches (e.g. if the view is a `UIButton`). The effect is that the button's `.onValue()` no longer triggers. The same goes for `pasteSignal` and `cutSignal`.

### Change
 This change installs the long press recognizer directly on the superview instead, and removes the `point(inside: with:)` override which otherwise blocks touches.

### Result
The effect is as expected: when observing a `UIButton`'s `copySignal`, the normal `.onValue()` is triggered as usual, and a long press makes the copy/paste/cut menu appear and function as intended. Disposing seems to remove the long press recognizer as well.

### Discussion
By doing this we slightly pollute the view being observed, but I think that's a worthwhile tradeoff for the feature working properly. Even though these signals are available on all `UIView`s, perhaps we should somehow make it clear that implementing this on `UIControl` instances can produce unexpected behavior.