### PR TITLE
Fix ThreadState never released when the thread gets closed

### DIFF
--- a/Flow/Scheduler.swift
+++ b/Flow/Scheduler.swift
@@ -214,6 +214,9 @@ var threadState: ThreadState {
 private let mainThreadState = ThreadState()
 private var _threadStateKey: pthread_key_t = 0
 private var threadStateKey: pthread_key_t = {
-    pthread_key_create(&_threadStateKey, nil)
+    let cleanup: @convention(c) (UnsafeMutableRawPointer) -> Void = { state in
+        Unmanaged<ThreadState>.fromOpaque(state).release()
+    }
+    pthread_key_create(&_threadStateKey, cleanup)
     return _threadStateKey
 }()


### PR DESCRIPTION
Noticed using the memory graph debugger that `ThreadState`s are never released.
So to fix that I added an observer to get notified when a thread is closed and release the corresponding `ThreadState`

@mansbernhardt Do you see a better way to fix this?