### PR TITLE
 Bugfix: Make sure `shared()` updates its last value before calling o…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.5.2
+
+- Bugfix: Make sure `shared()` updates its last value before calling out to get correct results in case of recursion.
+
 # 1.5.1
 
 - Update `combineLatest` to no longer allow mixing of plain and readable signals as for the returned signal to guarantee to be readable all provided signals must as be readable as well. This is technically a breaking of the API, but as the existing implementation is broken and might result in run-time crashes, this change can be considered as a bug-fix.

--- a/Flow/Info.plist
+++ b/Flow/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.1</string>
+	<string>1.5.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Flow/Signal+Transforms.swift
+++ b/Flow/Signal+Transforms.swift
@@ -52,15 +52,14 @@ public extension SignalProvider {
                 shared.unlock()
 
                 let disposable = signal.onEventType { eventType in
-                    if case .initial(let val?) = eventType {
+                    switch eventType {
+                    case .initial(let val?),
+                         .event(.value(let val)) where Kind.isReadable:
                         shared.updateLast(to: val)
+                    default: break
                     }
 
                     shared.callAll(with: eventType)
-
-                    if case .event(.value(let val)) = eventType, Kind.isReadable {
-                        shared.updateLast(to: val)
-                    }
                 }
                 shared.lock()
                 shared.disposable = disposable

--- a/FlowFramework.podspec
+++ b/FlowFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FlowFramework"
-  s.version      = "1.5.1"
+  s.version      = "1.5.2"
   s.module_name  = "Flow"
   s.summary      = "Working with asynchronous flows"
   s.description  = <<-DESC

--- a/FlowTests/SignalProviderTests.swift
+++ b/FlowTests/SignalProviderTests.swift
@@ -2145,6 +2145,23 @@ class SignalProviderTests: XCTestCase {
         XCTAssertEqual(getCnt, 3)
     }
 
+    func testRecursiveShared() {
+        let p = ReadWriteSignal(1).shared()
+        var results = [Int]()
+        let bag = DisposeBag()
+
+        bag += p.atOnce().enumerate().onValue { i, val in
+            results.append(val)
+            XCTAssertEqual(p.value, val) // Make sure value is up to date
+            if i == 0 {
+                p.value = 2
+            }
+        }
+
+        p.value = 3
+        XCTAssertEqual(results, [1, 2, 3])
+    }
+
     func testSignalShared() {
         var val = 0
 


### PR DESCRIPTION
…ut to get correct results in case of recursion.