### PR TITLE
Add tests for 'flatMapError'

### DIFF
--- a/Flow.xcodeproj/project.pbxproj
+++ b/Flow.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		215DEF311DEC365900CEB724 /* Recursive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215DEF301DEC365900CEB724 /* Recursive.swift */; };
 		215DEF371DEC368700CEB724 /* RecursiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215DEF351DEC367E00CEB724 /* RecursiveTests.swift */; };
 		21E1D41C1D9502A300A91CA0 /* Future+Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E1D41B1D9502A300A91CA0 /* Future+Signal.swift */; };
+		5BE9055B3538F1DDAB424AD2 /* FutureAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE90C011B621BC2F0B9C1B8 /* FutureAdditionsTests.swift */; };
 		7484FA6B212D9E930076FD3E /* Signal+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7484FA6A212D9E930076FD3E /* Signal+Debug.swift */; };
 		8E890FC106FB7A89BD1727CC /* EitherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E890194B06CBB3311E44757 /* EitherTests.swift */; };
 		F610ABAE1D91743500A161AB /* Future+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F610ABA71D91743500A161AB /* Future+Additions.swift */; };
@@ -81,6 +82,7 @@
 		215DEF301DEC365900CEB724 /* Recursive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Recursive.swift; path = Flow/Recursive.swift; sourceTree = SOURCE_ROOT; };
 		215DEF351DEC367E00CEB724 /* RecursiveTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RecursiveTests.swift; path = FlowTests/RecursiveTests.swift; sourceTree = SOURCE_ROOT; };
 		21E1D41B1D9502A300A91CA0 /* Future+Signal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Future+Signal.swift"; path = "Flow/Future+Signal.swift"; sourceTree = SOURCE_ROOT; };
+		5BE90C011B621BC2F0B9C1B8 /* FutureAdditionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FutureAdditionsTests.swift; path = FlowTests/FutureAdditionsTests.swift; sourceTree = "<group>"; };
 		7484FA6A212D9E930076FD3E /* Signal+Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Signal+Debug.swift"; path = "Flow/Signal+Debug.swift"; sourceTree = "<group>"; };
 		8E890194B06CBB3311E44757 /* EitherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EitherTests.swift; sourceTree = "<group>"; };
 		F610ABA61D91743500A161AB /* Future.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Future.swift; path = Flow/Future.swift; sourceTree = SOURCE_ROOT; };
@@ -303,6 +305,7 @@
 				F66835D32091C29C002D2676 /* UIViewSignalTests.swift */,
 				F6F679A220A966D1004C7AA7 /* EventListenerTests.swift */,
 				8E890194B06CBB3311E44757 /* EitherTests.swift */,
+				5BE90C011B621BC2F0B9C1B8 /* FutureAdditionsTests.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -513,6 +516,7 @@
 				F610ABBD1D91747000A161AB /* FutureQueueTests.swift in Sources */,
 				F610ABC11D91747000A161AB /* FutureUtilitiesTests.swift in Sources */,
 				8E890FC106FB7A89BD1727CC /* EitherTests.swift in Sources */,
+				5BE9055B3538F1DDAB424AD2 /* FutureAdditionsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FlowTests/FutureAdditionsTests.swift
+++ b/FlowTests/FutureAdditionsTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+import Flow
+
+class FutureAdditionsTests: XCTestCase {
+
+    func testFlatMapErrorTransformsFirstErrorInToSecondError() {
+        let expectation = self.expectation(description: "Error called")
+        expectation.assertForOverFulfill = true
+
+        Future<Int>() {
+                throw StubError.originalError
+            }
+            .flatMapError { _ in
+                throw StubTransformedError.transformedError
+            }
+            .onValue {
+                XCTFail("Expected error, got value \($0)")
+
+                expectation.fulfill()
+            }
+            .onError {
+                let error = $0 as? StubTransformedError
+                XCTAssertEqual(error, StubTransformedError.transformedError)
+
+                expectation.fulfill()
+            }
+
+        self.waitForExpectations(timeout: 1)
+    }
+
+    func testFlatMapErrorWhenFirstWorkerFailsAndSecondSucceedsReturnsExpectedValue() {
+        let firstWorker = StubWorker(stubWork: { _ in
+            throw StubError.originalError
+        })
+
+        let successfulWorker = StubWorker(stubWork: { _ in
+            return 2
+        })
+
+        let expectation = self.expectation(description: "Got value")
+        expectation.assertForOverFulfill = true
+
+        firstWorker.work()
+            .flatMapError { _ in successfulWorker.work() }
+            .onValue {
+                XCTAssertEqual(2, $0)
+
+                expectation.fulfill()
+            }
+            .onError {
+                XCTFail("Unexpected error: \($0)")
+
+                expectation.fulfill()
+            }
+
+        self.waitForExpectations(timeout: 10)
+    }
+
+    func testFlatMapErrorWhenFirstWorkerSucceedsReturnsExpectedValue() {
+        let firstWorker = StubWorker(stubWork: { _ in
+            return 2
+        })
+
+        let secondWorker = StubWorker(stubWork: { _ in
+            return 3
+        })
+
+        let expectation = self.expectation(description: "Got value")
+        expectation.assertForOverFulfill = true
+
+        firstWorker.work()
+            .flatMapError { _ in secondWorker.work() }
+            .onValue {
+                XCTAssertEqual(2, $0)
+
+                expectation.fulfill()
+            }
+            .onError {
+                XCTFail("Unexpected error: \($0)")
+
+                expectation.fulfill()
+            }
+
+        self.waitForExpectations(timeout: 10)
+    }
+}
+
+fileprivate final class StubWorker {
+
+    var stubWork: (Int) throws -> Int
+
+    init(
+        stubWork: @escaping (Int) throws -> Int
+    ) {
+        self.stubWork = stubWork
+    }
+
+    func work() -> Future<Int> {
+        return Future<Int>(1)
+            .map {
+                return try self.stubWork($0)
+            }
+            .delay(by: 0.1)
+    }
+}
+
+
+fileprivate enum StubError: Error, Equatable {
+    case originalError
+}
+
+fileprivate enum StubTransformedError: Error, Equatable {
+    case transformedError
+}


### PR DESCRIPTION
## What

We were using `flatMapError` in iZettle Pro and were having trouble understanding the intricacies of what errors get mapped and when.

To better understand it, I wrote some unit tests which do some "fake work" (a very small delay) and assert the values and errors are as we expect after transformation in `flatMapError`.

I've used `assertForOverFulfill` because we thought we might be seeing some odd behaviour around double firing of mapped values - if both `error` and `value` happen, the tests will fail.

Quite happy to make changes if you'd like, just let me know.

## Why

To document and verify the expected behaviour of `flatMapError`.

