### PR TITLE
[Discussion] with(weak:) convenience helper for breaking retain cycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.8
+
+- Added `deallocSignal(for:)` and `NSObject.deallocSignal` for listen on deallocation of objects.
+- Added signal transformation `with(weak:)` as a convenience helper for breaking retain cycles.
+
+# 1.7
+
+- Migration to Swift 5.
+
 # 1.6
 
  - Addition: Make `Callbacker` conform to `SignalProvider`.

--- a/Flow.xcodeproj/project.pbxproj
+++ b/Flow.xcodeproj/project.pbxproj
@@ -116,7 +116,7 @@
 		F688B941205FB78A00BA5A70 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		F688B942205FB78A00BA5A70 /* LICENSE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = LICENSE.md; sourceTree = "<group>"; };
 		F688B943205FB78A00BA5A70 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
-		F688B944205FB78B00BA5A70 /* FlowFramework.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = FlowFramework.podspec; sourceTree = "<group>"; };
+		F688B944205FB78B00BA5A70 /* FlowFramework.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = FlowFramework.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		F68EF3501FD58FBD0001129C /* Delegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Delegate.swift; path = Flow/Delegate.swift; sourceTree = "<group>"; };
 		F68EF3521FD58FC70001129C /* Event.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Event.swift; path = Flow/Event.swift; sourceTree = "<group>"; };
 		F68EF3541FD58FD20001129C /* UIView+Signal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIView+Signal.swift"; path = "Flow/UIView+Signal.swift"; sourceTree = "<group>"; };

--- a/Flow/Info.plist
+++ b/Flow/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.2</string>
+	<string>1.8.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Flow/Signal+Combiners.swift
+++ b/Flow/Signal+Combiners.swift
@@ -106,7 +106,7 @@ public extension SignalProvider {
     }
 
     /// Returns a new signal combining the latest value of `self` with the provided `object` up until `object` gets deallocated.
-    /// This is a convenience helper for break retain cycles in situations such as:
+    /// This is a convenience helper for breaking retain cycles in situations such as:
     ///
     ///     class Class {
     ///       let bag = DisposeBag()
@@ -213,6 +213,18 @@ public extension SignalProvider {
     /// - Note: See `with(weak:)` for more info.
     func with<T: AnyObject, A, B, C, D, E, F, G>(_ object: T) -> CoreSignal<Kind.DropWrite.DropWrite, (A, B, C, D, E, F, G, T)> where Value == (A, B, C, D, E, F, G) {
         return with(weak: object).map { ($0.0, $0.1, $0.2, $0.3, $0.4, $0.5, $0.6, $1) }
+    }
+
+    /// Returns a new signal combining the latest tuple value of `self` with the provided `object` up until `object` gets deallocated.
+    /// - Note: See `with(weak:)` for more info.
+    func with<T: AnyObject, A, B, C, D, E, F, G, H>(_ object: T) -> CoreSignal<Kind.DropWrite.DropWrite, (A, B, C, D, E, F, G, H, T)> where Value == (A, B, C, D, E, F, G, H) {
+        return with(weak: object).map { ($0.0, $0.1, $0.2, $0.3, $0.4, $0.5, $0.6, $0.7, $1) }
+    }
+
+    /// Returns a new signal combining the latest tuple value of `self` with the provided `object` up until `object` gets deallocated.
+    /// - Note: See `with(weak:)` for more info.
+    func with<T: AnyObject, A, B, C, D, E, F, G, H, I>(_ object: T) -> CoreSignal<Kind.DropWrite.DropWrite, (A, B, C, D, E, F, G, H, I, T)> where Value == (A, B, C, D, E, F, G, H, I) {
+        return with(weak: object).map { ($0.0, $0.1, $0.2, $0.3, $0.4, $0.5, $0.6, $0.7, $0.8, $1) }
     }
 }
 

--- a/Flow/Signal+Combiners.swift
+++ b/Flow/Signal+Combiners.swift
@@ -104,6 +104,137 @@ public extension SignalProvider {
             return state
         })
     }
+
+    /// Returns a new signal combining the latest value of `self` with the provided `object` up until `object` gets deallocated.
+    /// This is a convenience helper for break retain cycles in situations such as:
+    ///
+    ///     class Class {
+    ///       let bag = DisposeBag()
+    ///
+    ///       func setupUsingWeakCapture() {
+    ///         bag += someSignal.onValue { [weak self] value in
+    ///           guard let `self` = self else { return }
+    ///           self.handle(value)
+    ///       }
+    ///
+    ///       func setupWithWeak() {
+    ///         bag += someSignal.with(weak: self).onValue { value, `self` in
+    ///           self.handle(value)
+    ///       }
+    ///     }
+    ///
+    ///     a)---------b------c-----d--|
+    ///                |      |     |
+    ///     +--------------------------+
+    ///     | with(weak: o)            |
+    ///     +--------------------------+
+    ///                |      |     |
+    ///     (a,o))---(b,o)--(c,o)-(d,o)|
+    ///
+    func with<T: AnyObject>(weak object: T) -> CoreSignal<Kind.DropWrite, (Value, T)> {
+        let signal = providedSignal
+        return CoreSignal(onEventType: { [weak object] callback in
+            let state = StateAndCallback(state: (), callback: callback)
+
+            guard let object = object else {
+                return state
+            }
+
+            state += deallocSignal(for: object).onValue {
+                state.dispose()
+            }
+
+            state += signal.onEventType { [weak object] eventType in
+                guard let object = object else {
+                    state.call(.event(.end))
+                    return
+                }
+
+                switch eventType {
+                case .initial(nil):
+                    state.call(.initial(nil))
+                case .initial(let value?):
+                    state.call(.initial((value, object)))
+                case .event(.value(let value)):
+                    state.call(.event(.value((value, object))))
+                case .event(.end(let error)):
+                    state.call(.event(.end(error)))
+                }
+            }
+
+            return state
+        })
+    }
+
+    /// Returns a new signal combining the latest tuple value of `self` with the provided `object` up until `object` gets deallocated.
+    ///
+    ///     bag += combineLatest(a, b).with(weak: self).onValue { a, b, `self` in
+    ///       self.handle(a, b)
+    ///     }
+    ///
+    ///     (a,1))-----(b,1)-----(b,2)--|
+    ///                  |         |    |
+    ///     +---------------------------+
+    ///     | with(weak: o)             |
+    ///     +---------------------------+
+    ///                  |        |     |
+    ///     (a,1,o))--(b,1,o)--(b,2,o)--|
+    ///
+    /// - Note: See `with(weak:)` for more info.
+    func with<T: AnyObject, A, B>(weak object: T) -> CoreSignal<Kind.DropWrite.DropWrite, (A, B, T)> where Value == (A, B) {
+        return with(weak: object).map { ($0.0, $0.1, $1) }
+    }
+
+    /// Returns a new signal combining the latest tuple value of `self` with the provided `object` up until `object` gets deallocated.
+    /// - Note: See `with(weak:)` for more info.
+    func with<T: AnyObject, A, B, C>(weak object: T) -> CoreSignal<Kind.DropWrite.DropWrite, (A, B, C, T)> where Value == (A, B, C) {
+        return with(weak: object).map { ($0.0, $0.1, $0.2, $1) }
+    }
+
+    /// Returns a new signal combining the latest tuple value of `self` with the provided `object` up until `object` gets deallocated.
+    /// - Note: See `with(weak:)` for more info.
+    func with<T: AnyObject, A, B, C, D>(_ object: T) -> CoreSignal<Kind.DropWrite.DropWrite, (A, B, C, D, T)> where Value == (A, B, C, D) {
+        return with(weak: object).map { ($0.0, $0.1, $0.2, $0.3, $1) }
+    }
+
+    /// Returns a new signal combining the latest tuple value of `self` with the provided `object` up until `object` gets deallocated.
+    /// - Note: See `with(weak:)` for more info.
+    func with<T: AnyObject, A, B, C, D, E>(_ object: T) -> CoreSignal<Kind.DropWrite.DropWrite, (A, B, C, D, E, T)> where Value == (A, B, C, D, E) {
+        return with(weak: object).map { ($0.0, $0.1, $0.2, $0.3, $0.4, $1) }
+    }
+
+    /// Returns a new signal combining the latest tuple value of `self` with the provided `object` up until `object` gets deallocated.
+    /// - Note: See `with(weak:)` for more info.
+    func with<T: AnyObject, A, B, C, D, E, F>(_ object: T) -> CoreSignal<Kind.DropWrite.DropWrite, (A, B, C, D, E, F, T)> where Value == (A, B, C, D, E, F) {
+        return with(weak: object).map { ($0.0, $0.1, $0.2, $0.3, $0.4, $0.5, $1) }
+    }
+
+    /// Returns a new signal combining the latest tuple value of `self` with the provided `object` up until `object` gets deallocated.
+    /// - Note: See `with(weak:)` for more info.
+    func with<T: AnyObject, A, B, C, D, E, F, G>(_ object: T) -> CoreSignal<Kind.DropWrite.DropWrite, (A, B, C, D, E, F, G, T)> where Value == (A, B, C, D, E, F, G) {
+        return with(weak: object).map { ($0.0, $0.1, $0.2, $0.3, $0.4, $0.5, $0.6, $1) }
+    }
+}
+
+/// Returns a new signal signaling the provided `object` every time `self` signals, up until `object` gets deallocated.
+///
+///     bag += button.with(weak: self).onValue { `self` in
+///         self.handleButton()
+///     }
+///
+///     ())-----()-----()--|
+///             |      |   |
+///     +------------------+
+///     | with(weak: o)    |
+///     +------------------+
+///             |      |   |
+///     o)------o------o---|
+///
+/// - Note: See `with(weak:)` for more info.
+public extension SignalProvider where Value == () {
+    func with<T: AnyObject>(weak object: T) -> CoreSignal<Kind.DropWrite.DropWrite, T> {
+        return with(weak: object).map { $1 }
+    }
 }
 
 /// Returns a new signal merging the values emitted from `signals`

--- a/FlowFramework.podspec
+++ b/FlowFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FlowFramework"
-  s.version      = "1.5.2"
+  s.version      = "1.8.0"
   s.module_name  = "Flow"
   s.summary      = "Working with asynchronous flows"
   s.description  = <<-DESC


### PR DESCRIPTION
In typically usage of Flow using the frameworks Form and Presentation you seldom run into problems with retain cycles due to passing the responsibility of clean up to the callers of the APIs. However, if you don't have an architecture that matches that design philosophy or you are working to migrating a code base to that style you often have to handle retain cycles. The typical case is when having an reference value owning its own dispose bag, such as a view controller subclass:

```swift
///  Based on the login sample in this repo)
class LoginController: UIViewController {
    private let bag = DisposeBag()

    @IBOutlet var emailField: UITextField!
    @IBOutlet var passwordField: UITextField!
    @IBOutlet var loginButton: UIButton!
    @IBOutlet var cancelButton: UIBarButtonItem!

    var completion: (Result<User>) -> Void = { _ in }

    override func viewDidLoad() {
        super.viewDidLoad()
        
        // Retain cycle
        bag += cancelButton.onValue {
            self.completion(.failure(LoginError.dismissed))
        }
    }
```

We typically break the retain cycle by capturing self weakly:

```swift
        bag += cancelButton.onValue { [weak self] in
            guard let `self` = self else { return }
            self.completion(.failure(LoginError.dismissed))
        }
```

But this PR suggest to add a `with(weak:)` helper allowing you to more succinctly write:

```swift
        bag += cancelButton.with(weak: self).onValue { `self` in
            self.completion(.failure(LoginError.dismissed))
        }
```

`with(weak:)` has several overloads to allow you to work with no values as above as well as signals with single or multiple value (tuples):

```swift
        bag += emailField.with(weak: self).onValue { email, `self` in
            self.title = email
        }
```

```swift
        bag += combineLatest(emailField, passwordField).with(weak: self).onValue { email, password, `self` in
            self.loginButton.isEnabled = email.contains("@") && password.count > 4
        }
```



