### PR TITLE
Implement `contains` and `allSatisfy`

### DIFF
--- a/Flow/Signal+Transforms.swift
+++ b/Flow/Signal+Transforms.swift
@@ -377,6 +377,32 @@ public extension SignalProvider {
         })
     }
 
+    /// Returns a new signal returning boolean values where `true` means that at least one value so far has satisfied the given predicate.
+    ///
+    ///     ?)-----1---3-------2-------1-----|
+    ///            |   |       |       |
+    ///     +--------------------------------+
+    ///     | contains(where: { $0.isEven }) |
+    ///     +--------------------------------+
+    ///            |   |       |       |
+    ///     0)-----f---f-------t-------t-----|
+    func contains(on scheduler: Scheduler = .current, where predicate: @escaping (Value) -> Bool) -> CoreSignal<Kind.PotentiallyRead, Bool> {
+        return reduce(on: scheduler, false, combine: { $0 || predicate($1) })
+    }
+
+    /// Returns a new signal returning boolean values where `true` means that at all values so far have satisfied the given predicate.
+    ///
+    ///     ?)-----2---4-------1-------6-------|
+    ///            |   |       |       |
+    ///     +----------------------------------+
+    ///     | allSatisfy(where: { $0.isEven }) |
+    ///     +----------------------------------+
+    ///            |   |       |       |
+    ///     0)-----t---t-------f-------f-------|
+    func allSatisfy(on scheduler: Scheduler = .current, where predicate: @escaping (Value) -> Bool) -> CoreSignal<Kind.PotentiallyRead, Bool> {
+        return reduce(on: scheduler, true, combine: { $0 && predicate($1) })
+    }
+
     /// Returns a new signal returning pairs of count (starting from 0) and value
     ///     ?)---a----b----c----|
     ///          |    |    |

--- a/FlowTests/SignalProviderTests.swift
+++ b/FlowTests/SignalProviderTests.swift
@@ -352,6 +352,18 @@ class SignalProviderTests: XCTestCase {
         }
     }
 
+    func testContains() {
+        test([1, 3, 2, 5], expected: [false, false, true, true]) {
+            $0.contains(where: { $0 % 2 == 0 })
+        }
+    }
+
+    func testAllSatisfy() {
+        test([2, 4, 1, 6], expected: [true, true, false, false]) {
+            $0.allSatisfy(where: { $0 % 2 == 0 })
+        }
+    }
+
     func testEnumerate() {
         test([1, 2, 3, 4], expected: [(0, 1), (1, 2), (2, 3), (3, 4)], isEquivalent: ==) {
             $0.enumerate()


### PR DESCRIPTION
Using `reduce` for bool values on sequence types in the standard library is not recommended since the introduction of `contains` and `allSatisfy`. I think we could give Flow users a similar API by providing wrapper functions on top of `reduce`.