### PR TITLE
Fix swiftlint warning and type checker warning

### DIFF
--- a/Flow/FutureQueue.swift
+++ b/Flow/FutureQueue.swift
@@ -209,7 +209,7 @@ private protocol Executable: class {
     func cancel()
 }
 
-private final class QueueItem<Output> : Executable {
+private final class QueueItem<Output>: Executable {
     private let operation: () throws -> Future<Output>
     private let completion: (Result<Output>) -> ()
     private weak var future: Future<Output>?

--- a/Flow/Signal+Listeners.swift
+++ b/Flow/Signal+Listeners.swift
@@ -133,7 +133,7 @@ public extension SignalProvider where Kind == ReadWrite, Value: Equatable {
     /// Start listening on values for both `self` and `signal` and update each other's value with the latest signaled value.
     /// - Returns: A disposable that will stop listening on values when being disposed.
     /// - Note: Infinite recursion is avoided by comparing equality with the previous value.
-    func bidirectionallyBindTo<ReadWriteSignal: SignalProvider>(_ signal: ReadWriteSignal) -> Disposable where ReadWriteSignal.Value == Value, ReadWriteSignal.Kind == ReadWrite {
+    func bidirectionallyBindTo<ReadWriteSignalType: SignalProvider>(_ signal: ReadWriteSignalType) -> Disposable where ReadWriteSignalType.Value == Value, ReadWriteSignalType.Kind == ReadWrite {
         return bidirectionallyBindTo(signal, isSame: ==)
     }
 }

--- a/Flow/Signal+Transforms.swift
+++ b/Flow/Signal+Transforms.swift
@@ -43,7 +43,7 @@ public extension SignalProvider {
         let signal = providedSignal
         let shared = SharedState<Value>()
 
-        return CoreSignal(setValue: signal.setter, onEventType: { callback in
+        return CoreSignal(setValue: signal.setter, onEventType: { (callback: (@escaping (EventType) -> Void)) -> Disposable in
             let key = generateKey()
             shared.lock()
 

--- a/Flow/SignalProvider.swift
+++ b/Flow/SignalProvider.swift
@@ -40,7 +40,7 @@ public protocol SignalKind {
 }
 
 public extension SignalKind {
-    static var isReadable: Bool { return DropWrite.self == Read.self  }
+    static var isReadable: Bool { return (DropWrite.self == Read.self) as Bool }
 }
 
 /// A signal kind with no read nor write access

--- a/Flow/TargetActionable.swift
+++ b/Flow/TargetActionable.swift
@@ -31,9 +31,9 @@ public extension SignalProvider where Self: TargetActionable {
 
         (self as? AutoEnablable & HasEventListeners)?.updateAutomaticEnabling()
 
-        return Signal { callback in
+        return Signal { (callback: @escaping (()) -> Void) -> Disposable in
             let disposable = targetAction.addCallback { callback(()) }
-            return Disposer {
+            let disposer = Disposer {
                 disposable.dispose()
                 if targetAction.callbacker.isEmpty {
                     self.target = nil
@@ -41,6 +41,7 @@ public extension SignalProvider where Self: TargetActionable {
                     (self as? AutoEnablable & HasEventListeners)?.updateAutomaticEnabling()
                 }
             }
+            return disposer
         }.readable()
     }
 }


### PR DESCRIPTION
This fix removes some type-check warnings that were over 100ms and one swiftlint warning.