### PR TITLE
Add += operator for arrays of Disposable

### DIFF
--- a/Flow/Disposable.swift
+++ b/Flow/Disposable.swift
@@ -141,6 +141,18 @@ public func += (disposeBag: DisposeBag?, disposer: @escaping () -> Void) {
     disposeBag?.add(Disposer(disposer))
 }
 
+public func += (disposeBag: DisposeBag, disposables: [Disposable?]) {
+    disposables.compactMap { $0 }.forEach { disposable in
+        disposeBag += disposable
+    }
+}
+
+public func += (disposeBag: DisposeBag?, disposables: [Disposable?]) {
+    if let disposeBag = disposeBag {
+        disposeBag += disposables
+    }
+}
+
 public extension Disposable {
     /// Returns a future that will complete after `timeout`. Once completed or canceled, `self` will be disposed.
     @discardableResult

--- a/Flow/Disposable.swift
+++ b/Flow/Disposable.swift
@@ -142,7 +142,7 @@ public func += (disposeBag: DisposeBag?, disposer: @escaping () -> Void) {
 }
 
 public func += (disposeBag: DisposeBag, disposables: [Disposable?]) {
-    disposables.compactMap { $0 }.forEach { disposable in
+    disposables.forEach { disposable in
         disposeBag += disposable
     }
 }


### PR DESCRIPTION
Found this nifty in some cases, allows you to do stuff like:

```swift
signal.onValueDisposePrevious { anArray in
   let bag = DisposeBag()
   bag += anArray.map {
      // do something that returns a Disposable
   }
   return bag
}
```