### PR TITLE
Fix `replace` to execute on provided scheduler

### DIFF
--- a/Flow/Future+Additions.swift
+++ b/Flow/Future+Additions.swift
@@ -354,13 +354,13 @@ public extension Future {
 
     /// Will return a new future that will replace `self`'s result with a success `value` if `self` does not complete before `timeout`
     @discardableResult
-    func succeed(with value: Value, after timeout: TimeInterval) -> Future {
-        return replace(with: .success(value), after: timeout)
+    func succeed(on scheduler: Scheduler = .concurrentBackground, with value: Value, after timeout: TimeInterval) -> Future {
+        return replace(on: scheduler, with: .success(value), after: timeout)
     }
 
     /// Will return a new future that will replace `self`'s result with a failure `error` if `self` does not complete before `timeout`
     @discardableResult
-    func fail(with error: Error, after timeout: TimeInterval) -> Future {
-        return replace(with: .failure(error), after: timeout)
+    func fail(on scheduler: Scheduler = .concurrentBackground, with error: Error, after timeout: TimeInterval) -> Future {
+        return replace(on: scheduler, with: .failure(error), after: timeout)
     }
 }

--- a/Flow/Future.swift
+++ b/Flow/Future.swift
@@ -307,14 +307,16 @@ public extension Future {
         }
     }
 
-    /// Returns a new future that will replace `self`'s result with `result` if `self` does not complete before `timeout`.
+    /// Returns a new future that will replace `self`'s result with `result` on provided `scheduler` if `self` does not complete before `timeout`.
     @discardableResult
-    func replace(with result: Result<Value>, after timeout: TimeInterval) -> Future {
+    func replace(on scheduler: Scheduler = .current, with result: Result<Value>, after timeout: TimeInterval) -> Future {
         return Future(on: .none) { completion, mover in
             let future = mover.moveInside(self).onResult(on: .none, completion)
             return disposableAsync(after: timeout) {
-                future.cancel()
-                completion(result)
+                scheduler.async {
+                    future.cancel()
+                    completion(result)
+                }
             }
         }
     }

--- a/Flow/Future.swift
+++ b/Flow/Future.swift
@@ -309,14 +309,12 @@ public extension Future {
 
     /// Returns a new future that will replace `self`'s result with `result` on provided `scheduler` if `self` does not complete before `timeout`.
     @discardableResult
-    func replace(on scheduler: Scheduler = .current, with result: Result<Value>, after timeout: TimeInterval) -> Future {
+    func replace(on scheduler: Scheduler = .concurrentBackground, with result: Result<Value>, after timeout: TimeInterval) -> Future {
         return Future(on: .none) { completion, mover in
             let future = mover.moveInside(self).onResult(on: .none, completion)
-            return disposableAsync(after: timeout) {
-                scheduler.async {
+            return disposableAsync(on: scheduler, after: timeout) {
                     future.cancel()
                     completion(result)
-                }
             }
         }
     }

--- a/Flow/Scheduler.swift
+++ b/Flow/Scheduler.swift
@@ -152,8 +152,8 @@ public extension NSManagedObjectContext {
 #endif
 
 /// Used for scheduling delays and might be overridend in unit test with simulatated delays
-func disposableAsync(after delay: TimeInterval, execute work: @escaping () -> ()) -> Disposable {
-    return _disposableAsync(delay, work)
+func disposableAsync(on scheduler: Scheduler = .concurrentBackground, after delay: TimeInterval, execute work: @escaping () -> ()) -> Disposable {
+    return scheduler.disposableAsync(after: delay, execute: work)
 }
 
 private var _disposableAsync: (_ delay: TimeInterval, _ work: @escaping () -> ()) -> Disposable = Scheduler.concurrentBackground.disposableAsync

--- a/FlowTests/FutureUtilitiesTests.swift
+++ b/FlowTests/FutureUtilitiesTests.swift
@@ -98,7 +98,7 @@ class FutureUtilitiesTests: FutureTest {
     }
 
     func testReplaceWithResultOnCurrentScheduler() {
-        let e = expectation(description: "value")
+        let e = expectation(description: "initial future is disposed")
         testFuture {
             return Future<Int> { completion in
                 let bag = DisposeBag()

--- a/FlowTests/FutureUtilitiesTests.swift
+++ b/FlowTests/FutureUtilitiesTests.swift
@@ -97,8 +97,8 @@ class FutureUtilitiesTests: FutureTest {
         }
     }
 
-    func testReplaceWithResultOnCurrentScheduler() {
-        let e = expectation(description: "initial future is disposed")
+    func testSucceedWithResultOnMainScheduler() {
+        let e = expectation(description: "value")
         testFuture {
             return Future<Int> { completion in
                 let bag = DisposeBag()
@@ -107,7 +107,21 @@ class FutureUtilitiesTests: FutureTest {
                     e.fulfill()
                 }
                 return bag
-            }.replace(with: .success(8), after: 0.5)
+            }.succeed(on: .main, with: 8, after: 0.5)
+        }
+    }
+
+    func testSucceedWithResultOnConcurentBackground() {
+        let e = expectation(description: "value")
+        testFuture {
+            return Future<Int> { completion in
+                let bag = DisposeBag()
+                bag += {
+                    XCTAssertFalse(Thread.current.isMainThread)
+                    e.fulfill()
+                }
+                return bag
+            }.succeed(with: 8, after: 0.5)
         }
     }
 

--- a/FlowTests/FutureUtilitiesTests.swift
+++ b/FlowTests/FutureUtilitiesTests.swift
@@ -97,6 +97,20 @@ class FutureUtilitiesTests: FutureTest {
         }
     }
 
+    func testReplaceWithResultOnCurrentScheduler() {
+        let e = expectation(description: "value")
+        testFuture {
+            return Future<Int> { completion in
+                let bag = DisposeBag()
+                bag += {
+                    XCTAssertTrue(Thread.current.isMainThread)
+                    e.fulfill()
+                }
+                return bag
+            }.replace(with: .success(8), after: 0.5)
+        }
+    }
+
     func testReplaceWithResultNoTimeout() {
         let e = expectation(description: "value")
         testFuture(timeout: 1) {


### PR DESCRIPTION
**What's new**
Main Thread checker on Xcode 11 crashes when `replace` executes on the background for a future that should complete on the main thread. By providing a scheduler we make sure that the result is handled on the expected thread.