### PR TITLE
[APP-153] Add thread lock to prevent race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.8.3
+
+- Fix race conditions for iOS 13 for Signal and cleanup CallbackState<Value> 
+
 # 1.8.2
 
 - Fix the `traitCollectionWithFallback` behaviour on iOS 13 to return the view's predicted traits and prior iOS 13 to respect the key window's traits before falling back to the main screen traits.

--- a/Flow.xcodeproj/project.pbxproj
+++ b/Flow.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		215DEF311DEC365900CEB724 /* Recursive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215DEF301DEC365900CEB724 /* Recursive.swift */; };
 		215DEF371DEC368700CEB724 /* RecursiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215DEF351DEC367E00CEB724 /* RecursiveTests.swift */; };
 		21E1D41C1D9502A300A91CA0 /* Future+Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E1D41B1D9502A300A91CA0 /* Future+Signal.swift */; };
+		5B46DE3D22E9CC5E00E0A4D9 /* PrefetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B46DE3B22E9CBFA00E0A4D9 /* PrefetchTests.swift */; };
 		5BE9055B3538F1DDAB424AD2 /* FutureAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE90C011B621BC2F0B9C1B8 /* FutureAdditionsTests.swift */; };
 		7484FA6B212D9E930076FD3E /* Signal+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7484FA6A212D9E930076FD3E /* Signal+Debug.swift */; };
 		792AC15B227C8A6800F8BBAD /* SignalProviderTests+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792AC15A227C8A6800F8BBAD /* SignalProviderTests+Internal.swift */; };
@@ -83,6 +84,7 @@
 		215DEF301DEC365900CEB724 /* Recursive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Recursive.swift; path = Flow/Recursive.swift; sourceTree = SOURCE_ROOT; };
 		215DEF351DEC367E00CEB724 /* RecursiveTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RecursiveTests.swift; path = FlowTests/RecursiveTests.swift; sourceTree = SOURCE_ROOT; };
 		21E1D41B1D9502A300A91CA0 /* Future+Signal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Future+Signal.swift"; path = "Flow/Future+Signal.swift"; sourceTree = SOURCE_ROOT; };
+		5B46DE3B22E9CBFA00E0A4D9 /* PrefetchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefetchTests.swift; sourceTree = "<group>"; };
 		5BE90C011B621BC2F0B9C1B8 /* FutureAdditionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FutureAdditionsTests.swift; path = FlowTests/FutureAdditionsTests.swift; sourceTree = "<group>"; };
 		7484FA6A212D9E930076FD3E /* Signal+Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Signal+Debug.swift"; path = "Flow/Signal+Debug.swift"; sourceTree = "<group>"; };
 		792AC15A227C8A6800F8BBAD /* SignalProviderTests+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SignalProviderTests+Internal.swift"; sourceTree = "<group>"; };
@@ -309,6 +311,7 @@
 				F6F679A220A966D1004C7AA7 /* EventListenerTests.swift */,
 				8E890194B06CBB3311E44757 /* EitherTests.swift */,
 				5BE90C011B621BC2F0B9C1B8 /* FutureAdditionsTests.swift */,
+				5B46DE3B22E9CBFA00E0A4D9 /* PrefetchTests.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -517,6 +520,7 @@
 				792AC15B227C8A6800F8BBAD /* SignalProviderTests+Internal.swift in Sources */,
 				F6C0FED2202B44360076B877 /* DelegateTests.swift in Sources */,
 				F6F679A320A966D1004C7AA7 /* EventListenerTests.swift in Sources */,
+				5B46DE3D22E9CC5E00E0A4D9 /* PrefetchTests.swift in Sources */,
 				F610ABBD1D91747000A161AB /* FutureQueueTests.swift in Sources */,
 				F610ABC11D91747000A161AB /* FutureUtilitiesTests.swift in Sources */,
 				8E890FC106FB7A89BD1727CC /* EitherTests.swift in Sources */,

--- a/Flow/Info.plist
+++ b/Flow/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.2</string>
+	<string>1.8.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/FlowFramework.podspec
+++ b/FlowFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FlowFramework"
-  s.version      = "1.8.2"
+  s.version      = "1.8.3"
   s.module_name  = "Flow"
   s.summary      = "Working with asynchronous flows"
   s.description  = <<-DESC

--- a/FlowTests/Info.plist
+++ b/FlowTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.2</string>
+	<string>1.8.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/PrefetchTests.swift
+++ b/PrefetchTests.swift
@@ -1,0 +1,48 @@
+//
+//  PrefetchTests.swift
+//  Flow
+//
+//  Created by Martin on 2019-07-25.
+//  Copyright © 2019 iZettle. All rights reserved.
+//
+
+import XCTest
+import Flow
+
+private func prefetch<E: SignalProvider>(fetch: @escaping (_ isPrefetching: Bool) -> E) -> Signal<E.Value> {
+    return Signal { callback -> Disposable in
+        let bag = DisposeBag()
+        bag += fetch(true).take(first: 1).onValueDisposePrevious { value in
+            callback(value)
+            return fetch(false).onValue(callback)
+        }
+        return bag
+    }
+}
+
+class PrefetchTests: XCTestCase {
+    func testBasicPrefetch() {
+        let data = ReadWriteSignal(5)
+        let values = data//.startWith(1...5)
+
+        let bag = DisposeBag()
+        let signal = prefetch { isPrefetching -> Signal<Int> in
+            print("---- prefetch callback", isPrefetching)
+            return values.atOnce().atValue {
+                print("----- isPrefetching", isPrefetching, $0)
+                }.map {
+                    min(isPrefetching ? 10 : 20, $0)
+                }.plain()
+        }
+
+        var count = 0
+        bag += signal.onValue { val in
+            print("----- val", val)
+            count += val
+        }
+
+        data.value = 100
+
+        XCTAssertEqual(count, 5 + 5 + 20)
+    }
+}


### PR DESCRIPTION
On xCode 11 beta the methods `runExclusiveWithState` and `handleEventExclusiveWithState` create a race condition on the property `shouldCallInitial` and `exclusiveCount` by calling `beginExclusivity()`. Found that this is occurs when the signal has not terminated and `runExclusiveWithState` gets called. My proposed solution is to add a lock before the block accessing `shouldCallInitial` on line 247 of `Signal+Construction.swift`