### PR TITLE
Remove the traitCollection fallback on iOS 13 and bump Flow to 1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.8.2
+
+- Fix the `traitCollectionWithFallback` behaviour on iOS 13 to return the view's predicted traits and prior iOS 13 to respect the key window's traits before falling back to the main screen traits.
+
 # 1.8.1
 
 - Added signal transformations `contains(where:)` and `allSatisfy(where:)` as wrappers for boolean `reduce()` transforms.

--- a/Flow/Info.plist
+++ b/Flow/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.1</string>
+	<string>1.8.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Flow/UIView+Signal.swift
+++ b/Flow/UIView+Signal.swift
@@ -42,9 +42,18 @@ public extension UIView {
 }
 
 public extension UITraitEnvironment {
-    /// Returns the current traitCollection or the screen's traitCollection if `self` has no window
+    /// Returns the current traitCollection.
+    ///
+    /// Prior iOS 13 (where the traitCollection is always available), there is a fallback if `self` has no window - it falls back to the app's key window traitCollection or if that's not available to the main screen's traitCollection.
     var traitCollectionWithFallback: UITraitCollection {
-        return hasWindowTraitCollection ?? UIScreen.main.traitCollection
+        guard #available (iOS 13, *) else {
+            switch self {
+            case let view as UIView where view.window != nil: return view.traitCollection
+            case let viewController as UIViewController where viewController.isViewLoaded && viewController.view?.window != nil: return viewController.traitCollection
+            default: return UIApplication.shared.keyWindow?.traitCollection ?? UIScreen.main.traitCollection
+            }
+        }
+        return self.traitCollection
     }
 }
 
@@ -83,16 +92,6 @@ public extension UIView {
     @available(*, deprecated, renamed: "allDescendantsSignal")
     var allSubviewsSignal: ReadSignal<[UIView]> {
         return allDescendantsSignal
-    }
-}
-
-private extension UITraitEnvironment {
-    var hasWindowTraitCollection: UITraitCollection? {
-        switch self {
-        case let view as UIView where view.window != nil: return view.traitCollection
-        case let viewController as UIViewController where viewController.isViewLoaded && viewController.view?.window != nil: return viewController.traitCollection
-        default: return nil
-        }
     }
 }
 

--- a/FlowFramework.podspec
+++ b/FlowFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FlowFramework"
-  s.version      = "1.8.1"
+  s.version      = "1.8.2"
   s.module_name  = "Flow"
   s.summary      = "Working with asynchronous flows"
   s.description  = <<-DESC

--- a/FlowTests/Info.plist
+++ b/FlowTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.8.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
On iOS 13 UIKit now predicts the initial traits for a view before it's rendered so no need to return the screen's trait collection instead. Moreover, it's better to use the app's key window for determing the fallback traitCollection instead of the screen since for apps that support split screen that will be different based on the configuration chosen by the user.