### PR TITLE
Build and test on iOS 12 and 13 in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@ version: 2
 
 env:
   global:
-  - LC_CTYPE=en_US.UTF-8
-  - LANG=en_US.UTF-8
+    - LC_CTYPE=en_US.UTF-8
+    - LANG=en_US.UTF-8
 jobs:
   swiftlint:
     docker:
@@ -25,6 +25,22 @@ jobs:
             xcodebuild -showsdks
             swift -version
             sh build.sh test-iOS
+
+  test-iOS12:
+    macos:
+      xcode: "10.2.0"
+    steps:
+      - checkout
+      - run:
+          name: test iOS
+          command: |
+            set -o pipefail
+            xcodebuild -version
+            xcodebuild -showsdks
+            swift -version
+            IOS_SDK="iphonesimulator12.2" \
+                IOS_DESTINATION_PHONE="OS=12.2,name=iPhone Xs" \
+                sh build.sh test-iOS
 
   test-native:
     macos:
@@ -61,10 +77,13 @@ workflows:
       - swiftlint
       - test-native:
           requires:
-          - swiftlint
+            - swiftlint
       - test-iOS:
           requires:
-          - swiftlint
+            - swiftlint
+      - test-iOS12:
+          requires:
+            - swiftlint
       - examples:
           requires:
-          - swiftlint
+            - swiftlint

--- a/build.sh
+++ b/build.sh
@@ -7,8 +7,8 @@ set -o pipefail
 PROJECT="Flow.xcodeproj"
 SCHEME="Flow"
 
-IOS_SDK="iphonesimulator13.0"
-IOS_DESTINATION="OS=13.0,name=iPhone 8"
+IOS_SDK="${IOS_SDK:-"iphonesimulator13.0"}"
+IOS_DESTINATION_PHONE="${IOS_DESTINATION_PHONE:-"OS=13.0,name=iPhone Xs"}"
 
 usage() {
 cat << EOF
@@ -40,7 +40,7 @@ case "$COMMAND" in
     -project $PROJECT \
     -scheme "${SCHEME}" \
     -sdk "${IOS_SDK}" \
-    -destination "${IOS_DESTINATION}" \
+    -destination "${IOS_DESTINATION_PHONE}" \
     -configuration Debug ONLY_ACTIVE_ARCH=YES \
     CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO \
     build | xcpretty -c
@@ -60,7 +60,7 @@ case "$COMMAND" in
           -workspace "${example}Example.xcworkspace" \
           -scheme Example \
           -sdk "${IOS_SDK}" \
-          -destination "${IOS_DESTINATION}" \
+          -destination "${IOS_DESTINATION_PHONE}" \
           build
     done
     exit 0
@@ -71,7 +71,7 @@ case "$COMMAND" in
     -project $PROJECT \
     -scheme "${SCHEME}" \
     -sdk "${IOS_SDK}" \
-    -destination "${IOS_DESTINATION}" \
+    -destination "${IOS_DESTINATION_PHONE}" \
     -configuration Release \
     ONLY_ACTIVE_ARCH=YES \
     CODE_SIGNING_REQUIRED=NO \


### PR DESCRIPTION
Enable building and running on iOS 12 and 13 in parallel to prevent regressions.