### PR TITLE
Use swift result instead of custom result

### DIFF
--- a/Flow/Future+Additions.swift
+++ b/Flow/Future+Additions.swift
@@ -152,7 +152,7 @@ public extension Future {
     @discardableResult
     func onResultPassItThrough<O>(on scheduler: Scheduler = .current, _ callback: @escaping (Result<Value>) throws -> Future<O>) -> Future {
         return flatMapResult(on: scheduler) { result in
-            try callback(result).map { _ in try result.getValue() }
+            try callback(result).map { _ in try result.get() }
         }
     }
 

--- a/Flow/Future+Signal.swift
+++ b/Flow/Future+Signal.swift
@@ -56,7 +56,7 @@ public extension Future {
 
     /// Returns a signal that at the completion of `self` will signal the success value, unless a failure where the signal will be terminated with that failure error.
     var valueSignal: FiniteSignal<Value> {
-        return resultSignal.map { try $0.getValue() }
+        return resultSignal.map { try $0.get() }
     }
 
     /// Returns a signal that at the completion of `self` will signal the success value and thereafter terminate the signal, unless a failure where the signal will be terminated with that failure error.

--- a/Flow/Result.swift
+++ b/Flow/Result.swift
@@ -9,29 +9,16 @@
 import Foundation
 
 /// A value indicating either a `success` value or a `failure` error.
-public enum Result<Value> {
-    case success(Value)
-    case failure(Error)
-}
-
-public extension Result where Value == () {
-    /// Constant to allow writing `.success` instead of `.success(())` where a `Result<()>` is expected.
-    static var success: Result {
-        return .success(())
-    }
-}
+public typealias Result<Value> = Swift.Result<Value, Error>
 
 public extension Result {
-    /// Creates a new instance using the `Value` returned from the `getValue` closure.
-    /// If `getValue` throws an error, the instance will instead be set to `.failure(error)`
-    ///
-    ///     let result = Result { try evaluate() }
-    init(_ getValue: () throws -> Value) {
-        do {
-            self = .success(try getValue())
-        } catch {
-            self = .failure(error)
-        }
+    typealias Value = Success
+}
+
+public extension Result where Success == () {
+    /// Constant to allow writing `.success` instead of `.success(())` where a `Result<()>` is expected.
+    static var success: Flow.Result<Void> {
+        return .success(())
     }
 }
 
@@ -49,24 +36,11 @@ public extension Result {
     }
 
     /// Returns the value if `self` is .success or throw the error if self is `.failure`.
+    @available(*, deprecated, message: "Use Result.get()")
     func getValue() throws -> Value {
         switch self {
         case .success(let value): return value
         case .failure(let error): throw error
         }
-    }
-}
-
-public extension Result {
-    /// Returns a new value with result of transforming the `success` value using `transform`.
-    /// If `self` is an error or `transform` throws an error, the returned value will instead be `.failure(error)`.
-    func flatMap<O>(_ transform: (Value) throws -> Result<O>) -> Result<O> {
-        return Result<O> { try transform(getValue()).getValue() }
-    }
-
-    /// Returns a new `success` value from transforming the `success` value using `transform`.
-    /// If `self` is an error or `transform` throws an error, the returned value will instead be `.failure(error)`.
-    func map<O>(_ transform: (Value) throws -> O) -> Result<O> {
-        return flatMap { .success(try transform($0)) }
     }
 }

--- a/Flow/Scheduler.swift
+++ b/Flow/Scheduler.swift
@@ -73,7 +73,7 @@ public extension Scheduler {
     func sync<T>(execute work: () throws -> T) throws -> T {
         return try sync {
             Result { try work() }
-        }.getValue()
+        }.get()
     }
 
     /// Will asynchronously schedule `work` on `self` after `delay` seconds

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ PROJECT="Flow.xcodeproj"
 SCHEME="Flow"
 
 IOS_SDK="${IOS_SDK:-"iphonesimulator13.0"}"
-IOS_DESTINATION_PHONE="${IOS_DESTINATION_PHONE:-"OS=13.0,name=iPhone Xs"}"
+IOS_DESTINATION_PHONE="${IOS_DESTINATION_PHONE:-"OS=13.0,name=iPhone 11"}"
 
 usage() {
 cat << EOF


### PR DESCRIPTION
### What has been done

* Remove custom `Result` enum.
* Reimplement `Result` as a typealias to `Swift.Result` constrained on `Error`
* Deprecate `Result.getValue()` in favor of the provided `Result.get()`.
* Remove `Result.init(_:)` since it is a duplication of `Result.init(catching:)`. (This will have a minimal API change because most of the time trailing closure syntax will have been used, but it's still breaking nonetheless.)
* Remove `map` and `flatMap` since it is a pure reimplementation of the standard library functions.