### PR TITLE
APP-677: Fix compilation errors for swift 5.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,13 @@
 
 version: 2.1
 
-anchors: 
+anchors:
   - &test_device "iPhone Xs"
   - &clean_before_build true
   - &test_output_folder test_output
   - &default_executor
     macos:
-      xcode: "11.0.0"
+      xcode: "11.3.0"
 
 env:
   global:
@@ -31,7 +31,7 @@ commands:
     steps:
       - fetch-pod-specs # Fetch the podspec repo changes first to be sure to always get the latest pods
       - run:
-          command: | 
+          command: |
             cd <<parameters.path>>
             pod install --verbose
 
@@ -56,7 +56,7 @@ commands:
           path: <<parameters.path>>
           test_output_folder: *test_output_folder
 
-  # We introduced two separate commands for projects and workspaces because we didnt find a generic and non-confusing way to introduce 
+  # We introduced two separate commands for projects and workspaces because we didnt find a generic and non-confusing way to introduce
   # a condition to only pass either the project or the workspace environment argument to the fastlane scan
   test_project_and_store_results:
     description: "Builds and tests a project and then stores the results of the tests as artifacts and test results report"
@@ -120,12 +120,18 @@ jobs:
           path: swiftlint.html
           destination: swiftlint.html
 
+  test-xcode11-4-beta-ios13:
+    macos:
+      xcode: "11.4.0"
+    steps:
+      - test_main_project
+
   test-xcode10-ios12:
     macos:
       xcode: "10.3.0"
     steps:
       - test_main_project
-      
+
   test-xcode11-ios13:
     <<: *default_executor
     steps:
@@ -144,5 +150,6 @@ workflows:
       - swiftlint
       - test-xcode10-ios12
       - test-xcode11-ios13
+      - test-xcode11-4-beta-ios13
       - test-example-login
-      
+

--- a/Flow/CoreSignal.swift
+++ b/Flow/CoreSignal.swift
@@ -24,7 +24,7 @@ public final class CoreSignal<Kind: SignalKind, Value> {
     public typealias Event = Flow.Event<Value>
     typealias EventType = Flow.EventType<Value>
 
-    internal init(onEventType: @escaping (@escaping (EventType) -> Void) -> Disposable, _ noTrailingClosure: Void = ()) {
+    internal init(onEventType: @escaping (@escaping (EventType) -> Void) -> Disposable) {
         self.onEventType = onEventType
     }
 }

--- a/Flow/Signal+Scheduling.swift
+++ b/Flow/Signal+Scheduling.swift
@@ -71,7 +71,7 @@ public extension CoreSignal where Kind == Plain, Value == () {
     /// - Parameter delay: If provided will delay the first event by `delay`. If nil (default), `interval` will be used as the delay.
     convenience init(every interval: TimeInterval, delay: TimeInterval? = nil) {
         precondition(interval >= 0)
-        self.init { callback in
+        self.init(onValue: { callback in
             let bag = DisposeBag()
             guard interval.isFinite else { return bag }
 
@@ -93,7 +93,7 @@ public extension CoreSignal where Kind == Plain, Value == () {
             timer.resume()
 
             return bag
-        }
+        })
     }
 
     /// Creates a new signal that will signal once after `delay` seconds. Shorter version of `Signal(just: ()).delay(by: ...)`

--- a/Flow/Signal+Transforms.swift
+++ b/Flow/Signal+Transforms.swift
@@ -656,7 +656,7 @@ public extension SignalProvider {
     /// - Note: At most one value is hold at a time and released when `readSignal` becomes true.
     func wait(until readSignal: ReadSignal<Bool>) -> Signal<Value> {
         let signal = providedSignal
-        return Signal { callback in
+        return Signal(onValue: { callback in
             let state = StateAndCallback(state: Value?.none, callback: callback)
 
             state += signal.filter(on: .none) { _ in !readSignal.value }.onValue {
@@ -672,7 +672,7 @@ public extension SignalProvider {
             }.atValue(on: .none) { _ in state.protectedVal = nil }.onValue(on: .none, state.callback)
 
             return state
-        }
+        })
     }
 }
 

--- a/Flow/Signal+Utilities.swift
+++ b/Flow/Signal+Utilities.swift
@@ -11,12 +11,12 @@ import Foundation
 public extension NotificationCenter {
     /// Returns a signal for notifications named `name`.
     func signal(forName name: Notification.Name?, object: Any? = nil) -> Signal<Notification> {
-        return Signal { callback in
+        return Signal(onValue: { callback in
             let observer = self.addObserver(forName: name, object: object, queue: nil, using: callback)
             return Disposer {
                 self.removeObserver(observer)
             }
-        }
+        })
     }
 }
 

--- a/Flow/UIControls+Extensions.swift
+++ b/Flow/UIControls+Extensions.swift
@@ -15,7 +15,7 @@ public extension UIControl {
     ///
     ///     bag += textField.signal(for: .editingDidBegin).onValue { ... }
     func signal(for controlEvents: UIControl.Event) -> Signal<()> {
-        return Signal { callback in
+        return Signal(onValue: { callback in
             let targetAction = TargetAction()
             self.addTarget(targetAction, action: TargetAction.selector, for: controlEvents)
 
@@ -28,7 +28,7 @@ public extension UIControl {
                 self.updateAutomaticEnabling()
             }
             return bag
-        }
+        })
     }
 }
 
@@ -148,7 +148,7 @@ public extension UIBarButtonItem {
 
 extension UIGestureRecognizer: SignalProvider {
     public var providedSignal: ReadSignal<UIGestureRecognizer.State> {
-        return Signal { callback in
+        return Signal(onValue: { callback in
             let targetAction = TargetAction()
             self.addTarget(targetAction, action: TargetAction.selector)
             let bag = DisposeBag()
@@ -159,7 +159,7 @@ extension UIGestureRecognizer: SignalProvider {
                 self.removeTarget(targetAction, action: TargetAction.selector)
             }
             return bag
-        }.readable(initial: self.state)
+        }).readable(initial: self.state)
     }
 
     /// Returns a signal that will signal only for `state`, equivalent to `filter { $0 == forState }.toVoid()`

--- a/Flow/UIView+EditingMenu.swift
+++ b/Flow/UIView+EditingMenu.swift
@@ -14,34 +14,34 @@ public extension UIView {
     /// Returns a signal that will signal when user selects the copy command from the editing menu.
     /// - Note: Will display an editing menu on long press including the pasteboard actions currently listened on.
     var copySignal: Signal<()> {
-        return Signal { callback in
+        return Signal(onValue: { callback in
             let bag = DisposeBag()
             bag += self.copyingView.copyCallbacker.addCallback(callback)
             bag += { self.cleanUpCopyingView() }
             return bag
-        }
+        })
     }
 
     /// Returns a signal that will signal when user selects the paste command from the editing menu.
     /// - Note: Will display an editing menu on long press including the pasteboard actions currently listened on.
     var pasteSignal: Signal<()> {
-        return Signal { callback in
+        return Signal(onValue: { callback in
             let bag = DisposeBag()
             bag += self.copyingView.pasteCallbacker.addCallback(callback)
             bag += { self.cleanUpCopyingView() }
             return bag
-        }
+        })
     }
 
     /// Returns a signal that will signal when user selects the cut command from the editing menu.
     /// - Note: Will display an editing menu on long press including the pasteboard actions currently listened on.
     var cutSignal: Signal<()> {
-        return Signal { callback in
+        return Signal(onValue: { callback in
             let bag = DisposeBag()
             bag += self.copyingView.cutCallbacker.addCallback(callback)
             bag += { self.cleanUpCopyingView() }
             return bag
-        }
+        })
     }
 }
 

--- a/Flow/UIView+Signal.swift
+++ b/Flow/UIView+Signal.swift
@@ -97,7 +97,7 @@ public extension UIView {
 
 private extension UIView {
     func signal<T>(for keyPath: KeyPath<CallbackerView, Callbacker<T>>) -> Signal<T> {
-        return Signal { callback in
+        return Signal(onValue: { callback in
             let view = (self.viewWithTag(987892442) as? CallbackerView)  ?? {
                 let view = CallbackerView(frame: self.bounds)
                 view.autoresizingMask = [.flexibleWidth, .flexibleHeight] // trick so layoutsubViews is called when the view is resized
@@ -123,7 +123,7 @@ private extension UIView {
             bag += view[keyPath: keyPath].addCallback(callback)
 
             return bag
-        }
+        })
     }
 }
 

--- a/FlowTests/SignalProviderTests.swift
+++ b/FlowTests/SignalProviderTests.swift
@@ -1135,10 +1135,10 @@ class SignalProviderTests: XCTestCase {
     func testSharedSignal() {
         let callbacker = Callbacker<Int>()
         var s1 = 0
-        let s = Signal<Int> { c in
+        let s = Signal<Int>(onValue: { c in
             s1 += 1
             return callbacker.addCallback(c)
-        }
+        })
 
         var s2 = 0
         var s3 = 0
@@ -1179,10 +1179,10 @@ class SignalProviderTests: XCTestCase {
     func testSharedRemoveAndAdd() {
         let callbacker = Callbacker<Int>()
         var s0 = 0
-        let s = Signal<Int> { c in
+        let s = Signal<Int>(onValue: { c in
             s0 += 1
             return callbacker.addCallback(c)
-        }
+        })
 
         var s1 = 0
         var s2 = 0


### PR DESCRIPTION
The `noTrailingClosure` trick stopped working for swift 5.2. Remove that and fix the ambiguity. The explicit requirement is only a problem internally in the framework. External code will still be able to use the trailing closure syntax.