### PR TITLE
Wrap pthread mutex pointer in withUnsafeMutablePointer

### DIFF
--- a/Flow/Callbacker.swift
+++ b/Flow/Callbacker.swift
@@ -21,7 +21,7 @@ public final class Callbacker<Value> {
 
     private var callbacks = Callbacks.none
     private var _mutex = pthread_mutex_t()
-    private var mutex: PThreadMutex { return PThreadMutex(&_mutex) }
+    private var mutex: PThreadMutex { withUnsafeMutablePointer(to: &_mutex) { PThreadMutex($0) } }
 
     public init() {
         mutex.initialize()

--- a/Flow/Callbacker.swift
+++ b/Flow/Callbacker.swift
@@ -21,7 +21,9 @@ public final class Callbacker<Value> {
 
     private var callbacks = Callbacks.none
     private var _mutex = pthread_mutex_t()
-    private var mutex: PThreadMutex { withUnsafeMutablePointer(to: &_mutex) { PThreadMutex($0) } }
+    private var mutex: PThreadMutex {
+        return withUnsafeMutablePointer(to: &_mutex) { return PThreadMutex($0) }
+    }
 
     public init() {
         mutex.initialize()

--- a/Flow/Disposable.swift
+++ b/Flow/Disposable.swift
@@ -29,7 +29,7 @@ public struct NilDisposer: Disposable {
 public final class Disposer: Disposable {
     private var disposer: (() -> ())?
     private var _mutex = pthread_mutex_t()
-    private var mutex: PThreadMutex { return PThreadMutex(&_mutex) }
+    private var mutex: PThreadMutex { withUnsafeMutablePointer(to: &_mutex) { PThreadMutex($0) } }
 
     /// Pass a closure to be called when being disposed
     public init(_ disposer: @escaping () -> () = {}) {
@@ -59,7 +59,7 @@ public final class Disposer: Disposable {
 public final class DisposeBag: Disposable {
     private var disposables: [Disposable]
     private var _mutex = pthread_mutex_t()
-    private var mutex: PThreadMutex { return PThreadMutex(&_mutex) }
+    private var mutex: PThreadMutex { withUnsafeMutablePointer(to: &_mutex) { PThreadMutex($0) } }
 
     /// Create an empty instance
     public init() {

--- a/Flow/Disposable.swift
+++ b/Flow/Disposable.swift
@@ -29,7 +29,9 @@ public struct NilDisposer: Disposable {
 public final class Disposer: Disposable {
     private var disposer: (() -> ())?
     private var _mutex = pthread_mutex_t()
-    private var mutex: PThreadMutex { withUnsafeMutablePointer(to: &_mutex) { PThreadMutex($0) } }
+    private var mutex: PThreadMutex {
+        return withUnsafeMutablePointer(to: &_mutex) { return PThreadMutex($0) }
+    }
 
     /// Pass a closure to be called when being disposed
     public init(_ disposer: @escaping () -> () = {}) {
@@ -59,7 +61,9 @@ public final class Disposer: Disposable {
 public final class DisposeBag: Disposable {
     private var disposables: [Disposable]
     private var _mutex = pthread_mutex_t()
-    private var mutex: PThreadMutex { withUnsafeMutablePointer(to: &_mutex) { PThreadMutex($0) } }
+    private var mutex: PThreadMutex {
+        return withUnsafeMutablePointer(to: &_mutex) { return PThreadMutex($0) }
+    }
 
     /// Create an empty instance
     public init() {

--- a/Flow/Future.swift
+++ b/Flow/Future.swift
@@ -327,7 +327,7 @@ func memPrint(_ str: String, _ count: Int32) {
 }
 
 private extension Future {
-    var mutex: PThreadMutex { return PThreadMutex(&_mutex) }
+    var mutex: PThreadMutex { withUnsafeMutablePointer(to: &_mutex) { PThreadMutex($0) } }
 
     private var protectedState: State {
         return mutex.protect { state }

--- a/Flow/Future.swift
+++ b/Flow/Future.swift
@@ -327,7 +327,9 @@ func memPrint(_ str: String, _ count: Int32) {
 }
 
 private extension Future {
-    var mutex: PThreadMutex { withUnsafeMutablePointer(to: &_mutex) { PThreadMutex($0) } }
+    var mutex: PThreadMutex {
+        return withUnsafeMutablePointer(to: &_mutex) { return PThreadMutex($0) }
+    }
 
     private var protectedState: State {
         return mutex.protect { state }

--- a/Flow/FutureQueue.swift
+++ b/Flow/FutureQueue.swift
@@ -169,7 +169,7 @@ public extension FutureQueue {
 }
 
 private extension FutureQueue {
-    var mutex: PThreadMutex { return PThreadMutex(&_mutex) }
+    var mutex: PThreadMutex { withUnsafeMutablePointer(to: &_mutex) { PThreadMutex($0) } }
     func lock() { mutex.lock() }
     func unlock() { mutex.unlock() }
 
@@ -231,7 +231,7 @@ private final class QueueItem<Output>: Executable {
         memPrint("Queue Item deinit", queueItemUnitTestAliveCount)
     }
 
-    private var mutex: PThreadMutex { return PThreadMutex(&_mutex) }
+    private var mutex: PThreadMutex { withUnsafeMutablePointer(to: &_mutex) { PThreadMutex($0) } }
     private func lock() { mutex.lock() }
     private func unlock() { mutex.unlock() }
 

--- a/Flow/FutureQueue.swift
+++ b/Flow/FutureQueue.swift
@@ -169,7 +169,9 @@ public extension FutureQueue {
 }
 
 private extension FutureQueue {
-    var mutex: PThreadMutex { withUnsafeMutablePointer(to: &_mutex) { PThreadMutex($0) } }
+    var mutex: PThreadMutex {
+        return withUnsafeMutablePointer(to: &_mutex) { return PThreadMutex($0) }
+    }
     func lock() { mutex.lock() }
     func unlock() { mutex.unlock() }
 
@@ -231,7 +233,9 @@ private final class QueueItem<Output>: Executable {
         memPrint("Queue Item deinit", queueItemUnitTestAliveCount)
     }
 
-    private var mutex: PThreadMutex { withUnsafeMutablePointer(to: &_mutex) { PThreadMutex($0) } }
+    private var mutex: PThreadMutex {
+        return withUnsafeMutablePointer(to: &_mutex) { return PThreadMutex($0) }
+    }
     private func lock() { mutex.lock() }
     private func unlock() { mutex.unlock() }
 

--- a/Flow/Locking.swift
+++ b/Flow/Locking.swift
@@ -11,7 +11,9 @@ import Foundation
 /// A reference wrapper around a POSIX thread mutex
 public final class Mutex {
     private var _mutex = pthread_mutex_t()
-    private var mutex: PThreadMutex { withUnsafeMutablePointer(to: &_mutex) { PThreadMutex($0) } }
+    private var mutex: PThreadMutex {
+        return withUnsafeMutablePointer(to: &_mutex) { return PThreadMutex($0) }
+    }
 
     public init() {
         mutex.initialize()
@@ -87,7 +89,9 @@ final class StateAndCallback<Value, State>: Disposable {
     var val: State
     fileprivate var disposables = [Disposable]()
     private var _mutex = pthread_mutex_t()
-    fileprivate var mutex: PThreadMutex { withUnsafeMutablePointer(to: &_mutex) { PThreadMutex($0) } }
+    fileprivate var mutex: PThreadMutex {
+        return withUnsafeMutablePointer(to: &_mutex) { return PThreadMutex($0) }
+    }
 
     init(state: State, callback: @escaping (Value) -> ()) {
         val = state

--- a/Flow/Locking.swift
+++ b/Flow/Locking.swift
@@ -11,7 +11,7 @@ import Foundation
 /// A reference wrapper around a POSIX thread mutex
 public final class Mutex {
     private var _mutex = pthread_mutex_t()
-    private var mutex: PThreadMutex { return PThreadMutex(&_mutex) }
+    private var mutex: PThreadMutex { withUnsafeMutablePointer(to: &_mutex) { PThreadMutex($0) } }
 
     public init() {
         mutex.initialize()
@@ -87,7 +87,7 @@ final class StateAndCallback<Value, State>: Disposable {
     var val: State
     fileprivate var disposables = [Disposable]()
     private var _mutex = pthread_mutex_t()
-    fileprivate var mutex: PThreadMutex { return PThreadMutex(&_mutex) }
+    fileprivate var mutex: PThreadMutex { withUnsafeMutablePointer(to: &_mutex) { PThreadMutex($0) } }
 
     init(state: State, callback: @escaping (Value) -> ()) {
         val = state

--- a/Flow/OrderedCallbacker.swift
+++ b/Flow/OrderedCallbacker.swift
@@ -15,7 +15,7 @@ import Foundation
 public final class OrderedCallbacker<OrderedValue, CallbackValue> {
     private var callbacks: [Key: (OrderedValue, (CallbackValue) -> Future<()>)] = [:]
     private var _mutex = pthread_mutex_t()
-    private var mutex: PThreadMutex { return PThreadMutex(&_mutex) }
+    private var mutex: PThreadMutex { withUnsafeMutablePointer(to: &_mutex) { PThreadMutex($0) } }
 
     public init() {
         mutex.initialize()

--- a/Flow/OrderedCallbacker.swift
+++ b/Flow/OrderedCallbacker.swift
@@ -15,7 +15,9 @@ import Foundation
 public final class OrderedCallbacker<OrderedValue, CallbackValue> {
     private var callbacks: [Key: (OrderedValue, (CallbackValue) -> Future<()>)] = [:]
     private var _mutex = pthread_mutex_t()
-    private var mutex: PThreadMutex { withUnsafeMutablePointer(to: &_mutex) { PThreadMutex($0) } }
+    private var mutex: PThreadMutex {
+        return withUnsafeMutablePointer(to: &_mutex) { return PThreadMutex($0) }
+    }
 
     public init() {
         mutex.initialize()

--- a/Flow/Signal+Construction.swift
+++ b/Flow/Signal+Construction.swift
@@ -113,7 +113,9 @@ private final class CallbackState<Value>: Disposable {
     let sharedKey: Key
 
     private var _mutex = pthread_mutex_t()
-    private var mutex: PThreadMutex { withUnsafeMutablePointer(to: &_mutex) { PThreadMutex($0) } }
+    private var mutex: PThreadMutex {
+        return withUnsafeMutablePointer(to: &_mutex) { return PThreadMutex($0) }
+    }
 
     init(shared: SharedState<Value>? = nil, getValue: (() -> Value)?, callback: @escaping (EventType<Value>) -> Void) {
         self.shared = shared
@@ -293,7 +295,9 @@ private final class CallbackState<Value>: Disposable {
 final class SharedState<Value> {
     private let getValue: (() -> Value)?
     private var _mutex = pthread_mutex_t()
-    private var mutex: PThreadMutex { withUnsafeMutablePointer(to: &_mutex) { PThreadMutex($0) } }
+    private var mutex: PThreadMutex {
+        return withUnsafeMutablePointer(to: &_mutex) { return PThreadMutex($0) }
+    }
 
     typealias Callback = (EventType<Value>) -> Void
     var firstCallback: (key: Key, value: Callback)?

--- a/Flow/Signal+Construction.swift
+++ b/Flow/Signal+Construction.swift
@@ -113,7 +113,7 @@ private final class CallbackState<Value>: Disposable {
     let sharedKey: Key
 
     private var _mutex = pthread_mutex_t()
-    private var mutex: PThreadMutex { return PThreadMutex(&_mutex) }
+    private var mutex: PThreadMutex { withUnsafeMutablePointer(to: &_mutex) { PThreadMutex($0) } }
 
     init(shared: SharedState<Value>? = nil, getValue: (() -> Value)?, callback: @escaping (EventType<Value>) -> Void) {
         self.shared = shared
@@ -293,7 +293,7 @@ private final class CallbackState<Value>: Disposable {
 final class SharedState<Value> {
     private let getValue: (() -> Value)?
     private var _mutex = pthread_mutex_t()
-    private var mutex: PThreadMutex { return PThreadMutex(&_mutex) }
+    private var mutex: PThreadMutex { withUnsafeMutablePointer(to: &_mutex) { PThreadMutex($0) } }
 
     typealias Callback = (EventType<Value>) -> Void
     var firstCallback: (key: Key, value: Callback)?

--- a/Flow/Signal+Scheduling.swift
+++ b/Flow/Signal+Scheduling.swift
@@ -120,7 +120,9 @@ internal extension CoreSignal {
 private final class OnEventTypeDisposer<Value>: Disposable {
     private var disposable: Disposable?
     private var _mutex = pthread_mutex_t()
-    private var mutex: PThreadMutex { withUnsafeMutablePointer(to: &_mutex) { PThreadMutex($0) } }
+    private var mutex: PThreadMutex {
+        return withUnsafeMutablePointer(to: &_mutex) { return PThreadMutex($0) }
+    }
     private let scheduler: Scheduler
     private var callback: ((EventType<Value>) -> Void)?
 

--- a/Flow/Signal+Scheduling.swift
+++ b/Flow/Signal+Scheduling.swift
@@ -120,7 +120,7 @@ internal extension CoreSignal {
 private final class OnEventTypeDisposer<Value>: Disposable {
     private var disposable: Disposable?
     private var _mutex = pthread_mutex_t()
-    private var mutex: PThreadMutex { return PThreadMutex(&_mutex) }
+    private var mutex: PThreadMutex { withUnsafeMutablePointer(to: &_mutex) { PThreadMutex($0) } }
     private let scheduler: Scheduler
     private var callback: ((EventType<Value>) -> Void)?
 


### PR DESCRIPTION
This is done to address such warnings:
`Initialization of 'PThreadMutex' (aka 'UnsafeMutablePointer<_opaque_pthread_mutex_t>') results in a dangling pointer`
which we started seeing recently. 

This is what Xcode suggests:
```
1. Implicit argument conversion from 'pthread_mutex_t' (aka '_opaque_pthread_mutex_t') to 'UnsafeMutablePointer<pthread_mutex_t>' (aka 'UnsafeMutablePointer<_opaque_pthread_mutex_t>') produces a pointer valid only for the duration of the call to 'init(_:)'

2. Use 'withUnsafeMutablePointer' in order to explicitly convert argument to pointer valid for a defined scope
```

I don't fully understand if this fixes a potential problem or workarounds it -I hope that this is enough for safer memory usage. Tests pass.
