### PR TITLE
Specify type of the library for `spm` builds 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.10.2
+- Specify type of the library for `spm` builds as `dynamic`
+
 # 1.10.1
 
 - Xcode 13.2 compatibility

--- a/Flow.xcodeproj/project.pbxproj
+++ b/Flow.xcodeproj/project.pbxproj
@@ -673,7 +673,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MARKETING_VERSION = 1.10.1;
+				MARKETING_VERSION = 1.10.2;
 				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-long-function-bodies=300 -Xfrontend -warn-long-expression-type-checking=300";
 				PRODUCT_BUNDLE_IDENTIFIER = com.iZettle.Flow;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -701,7 +701,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MARKETING_VERSION = 1.10.1;
+				MARKETING_VERSION = 1.10.2;
 				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-long-function-bodies=300 -Xfrontend -warn-long-expression-type-checking=300";
 				PRODUCT_BUNDLE_IDENTIFIER = com.iZettle.Flow;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/FlowFramework.podspec
+++ b/FlowFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FlowFramework"
-  s.version      = "1.10.1"
+  s.version      = "1.10.2"
   s.module_name  = "Flow"
   s.summary      = "Working with asynchronous flows"
   s.description  = <<-DESC

--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
     products: [
         .library(
             name: "Flow",
+            type: .dynamic,
             targets: ["Flow"]),
     ],
     targets: [


### PR DESCRIPTION
Type of the library is used to determine how to link to the library. In
order to avoid `Swift Package Manager` selecting on its own between static or
dynamic linking based on the preference of the package’s consumer, we declare
that `Flow` is dynamic.

In certain situations lack of declaration can cause `ITMS-90334` error during
export. This happens when main project has multiple target "frameworks"
that require `Flow` to be a part of their direct dependency tree, being
added inside `Package Dependency`. `xcodebuild-archive.log` can be used
to determine that `Flow` is added into every sub target.

```
Root-Project
│   │
│   └── Flow (via spm)
│
├── Sub-Project-1
│   │
│   └── Flow (via spm)
│
├── Sub-Project-2
│
├── Sub-Project-3
│   │
│   └── Flow (via spm)
│
├── Sub-Project-4
│   │
│   └── Flow (via spm)

```

Specific error is not however related to the fact that library can be
found within each `Sub-Project`s:

```
Invalid Code Signature Identifier. The identifier
"Flow-55554944542d58344c0436e8ab4f9777902caaca" in your code signature for
"Flow_5CCDAD45C_PackageProduct" must match its Bundle Identifier "Flow"
```

Error above relates to fact that when inspecting `Info.plist` of
`Flow_5CCDAD45C_PackageProduct` inside
`*.xcarchive/Products/Applications/*.app/Frameworks` dir, value for
`Bundle identifier` equals to `Flow` rather then expected
`com.iZettle.Flow`.

Without decalring `Flow` as `dynamic`, `spm` places it inside
`*.xcarchive/Products/Applications/*.app/Frameworks` dir.