### PR TITLE
Remove `dynamic` from package definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.12.1
+- Remove `dynamic` type from `spm` builds
+
 # 1.12.0
 - Xcode 16.0 compatibility
 

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,6 @@ let package = Package(
     products: [
         .library(
             name: "Flow",
-            type: .dynamic,
             targets: ["Flow"]),
     ],
     targets: [


### PR DESCRIPTION
Removing in order to make the `Flow` compatible with `Form`.

`dynamic` definition caused build problems for any `Flow` import above `1.10.1` in `Form`.